### PR TITLE
Feat/공통 의존성에 spring-boot-starter-validation 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ configure(subprojects.findAll { it.name.endsWith("-service") }) {
         implementation 'org.springframework.retry:spring-retry'
         implementation 'org.springframework.boot:spring-boot-starter-aop'
         implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+        implementation 'org.springframework.boot:spring-boot-starter-validation'
     }
 }
 

--- a/eureka-server/build.gradle
+++ b/eureka-server/build.gradle
@@ -1,9 +1,5 @@
-dependencies {
-	// Eureka Server 기능
-	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-server'
-	// docker-compose healthcheck 엔드포인트
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-}
+// eureka-server/build.gradle
+// 공통 의존성은 루트/build.gradle configure 블록에서 관리합니다
 
 bootJar {
 	archiveFileName = 'eureka-server.jar'


### PR DESCRIPTION
## 📋 관련 이슈
> 관련 이슈 번호를 적어주세요.
- close #15 

## 🔧 작업 내용
> 서비스 공통 의존성에 validation 추가
> 루트/build.gradle에 `implementation 'org.springframework.boot:spring-boot-starter-validation` 추가

## ✅ 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [x] 불필요한 주석/코드를 제거했나요?
- [x] 로컬에서 테스트 완료했나요?

## 📝 리뷰 요청 사항
> 서비스 공통으로 사용하는 의존성이므로 일반 서비스용 의존성 목록에 추가합니다.




