### PR TITLE
chore: springdoc-openapi (swagger) 의존성 버전 충돌 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ configure(subprojects.findAll { it.name.endsWith("-service") }) {
         implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
         implementation 'org.springframework.retry:spring-retry'
         implementation 'org.springframework.boot:spring-boot-starter-aop'
-        implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+        implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
         implementation 'org.springframework.boot:spring-boot-starter-validation'
     }
 }


### PR DESCRIPTION
## 📋 관련 이슈
> 관련 이슈 번호를 적어주세요.
- close #21 

## 🔧 작업 내용
- 루트 build.gradle 버전 업그레이드
```
// 2.3.0 → 2.8.6
  implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
```  
루트 설정이므로 전체 서비스 재빌드 필요

## ✅ 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [x] 불필요한 주석/코드를 제거했나요?
- [x] 로컬에서 테스트 완료했나요?
- [ ] API 명세서와 일치하나요?

## 📝 리뷰 요청 사항
- 기존 버전에서 swagger 문서 조회 접근시 500에러
- NoSuchMethodError: ControllerAdviceBean.<init>(java.lang.Object)
- 원인: springdoc-openapi 2.3.0이 Spring Boot 3.5.x(Spring Framework 6.2.x)와 호환 안됨
- ControllerAdviceBean 생성자 시그니처가 변경이 주된 이

## 📷 스크린샷
<img width="1574" height="907" alt="image" src="https://github.com/user-attachments/assets/905e345c-17eb-483f-9dde-3e2629589318" />



