### PR TITLE
Feat/company-service CRUD API + 테스트 코드

### DIFF
--- a/company-service/build.gradle
+++ b/company-service/build.gradle
@@ -1,3 +1,9 @@
 bootJar {
 	archiveFileName = 'company-service.jar'
 }
+// Java 21 + Mockito 조합에서 Mockito가 동적으로 agent를 로드하는 방식이
+// 추후 JDK에서 막힐거라는 경고문 발생 (테스트시)
+// 해당 부분 추가로 방지
+tasks.withType(Test).configureEach {
+	jvmArgs '-XX:+EnableDynamicAgentLoading'
+}

--- a/company-service/src/main/java/com/sparta/lucky/company/application/CompanyService.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/application/CompanyService.java
@@ -38,9 +38,18 @@ public class CompanyService {
     public CreateCompanyResult createCompany(CreateCompanyCommand command) {
         log.info("업체 생성 요청 - requester: {}, role: {}, hubId: {}",
                 command.getRequesterId(), command.getRequesterRole(), command.getHubId());
+
+        // MASTER, HUB_MANAGER만 생성 가능
+        if (!ROLE_MASTER.equals(command.getRequesterRole())
+                && !ROLE_HUB_MANAGER.equals(command.getRequesterRole())) {
+            log.warn("업체 생성 권한 없음 - requester: {}, role: {}",
+                    command.getRequesterId(), command.getRequesterRole());
+            throw new BusinessException(CompanyErrorCode.COMPANY_ACCESS_DENIED);
+        }
+
         // HUB_MANAGER는 자신의 허브에만 업체 생성 가능
         if (ROLE_HUB_MANAGER.equals(command.getRequesterRole())) {
-            if (!command.getHubId().equals(command.getRequesterHubId())) {
+            if (command.getHubId() == null || !command.getHubId().equals(command.getRequesterHubId())) {
                 log.warn("업체 생성 권한 없음 - requester: {}, 요청 hubId: {}, 소속 hubId: {}",
                         command.getRequesterId(), command.getHubId(), command.getRequesterHubId());
                 throw new BusinessException(CompanyErrorCode.COMPANY_HUB_MISMATCH);
@@ -166,6 +175,12 @@ public class CompanyService {
      * COMPANY_MANAGER — 자기 소속 업체만
      */
     private void validateUpdateAccess(Company company, UpdateCompanyCommand command) {
+        // null 체크 우선 진행
+        if (command.getRequesterRole() == null) {
+            log.warn("업체 수정 권한 없음 - 역할 정보 없음, requester: {}", command.getRequesterId());
+            throw new BusinessException(CompanyErrorCode.COMPANY_ACCESS_DENIED);
+        }
+
         switch (command.getRequesterRole()) {
             case ROLE_MASTER -> { /* 전체 허용 */ }
             case ROLE_HUB_MANAGER -> {

--- a/company-service/src/main/java/com/sparta/lucky/company/application/CompanyService.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/application/CompanyService.java
@@ -1,0 +1,192 @@
+package com.sparta.lucky.company.application;
+
+import com.sparta.lucky.company.application.dto.*;
+import com.sparta.lucky.company.common.exception.BusinessException;
+import com.sparta.lucky.company.domain.Company;
+import com.sparta.lucky.company.domain.CompanyErrorCode;
+import com.sparta.lucky.company.domain.CompanyRepository;
+import com.sparta.lucky.company.domain.CompanyType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * 역할 검증은 게이트웨이 구현 완료 후 @PreAuthorize로 교체? - 협의필요
+ */
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)  // 기본 읽기 전용, 쓰기는 각 메서드에 @Transactional 추가
+public class CompanyService {
+
+    // 매직스트링 상수화
+    private static final String ROLE_MASTER = "MASTER";
+    private static final String ROLE_HUB_MANAGER = "HUB_MANAGER";
+    private static final String ROLE_COMPANY_MANAGER = "COMPANY_MANAGER";
+
+    private final CompanyRepository companyRepository;
+    // TODO: HubClient hubClient — hub 존재 여부 검증 (hub-service 구현 후 추가)
+    // TODO: ProductInternalClient productClient — 업체 삭제 시 상품 일괄 삭제
+
+    @Transactional
+    public CreateCompanyResult createCompany(CreateCompanyCommand command) {
+        log.info("업체 생성 요청 - requester: {}, role: {}, hubId: {}",
+                command.getRequesterId(), command.getRequesterRole(), command.getHubId());
+        // HUB_MANAGER는 자신의 허브에만 업체 생성 가능
+        if (ROLE_HUB_MANAGER.equals(command.getRequesterRole())) {
+            if (!command.getHubId().equals(command.getRequesterHubId())) {
+                log.warn("업체 생성 권한 없음 - requester: {}, 요청 hubId: {}, 소속 hubId: {}",
+                        command.getRequesterId(), command.getHubId(), command.getRequesterHubId());
+                throw new BusinessException(CompanyErrorCode.COMPANY_HUB_MISMATCH);
+            }
+        }
+
+        // TODO: hubClient.getHub(command.getHubId()) — 허브 실존 여부 검증
+
+        Company company = Company.builder()
+                .name(command.getName())
+                .companyType(command.getCompanyType())
+                .hubId(command.getHubId())
+                .address(command.getAddress())
+                // manager는 생성 시 null — MASTER가 내부 API로 나중에 배정
+                .build();
+
+        CreateCompanyResult result = CreateCompanyResult.from(companyRepository.save(company));
+        log.info("업체 생성 완료 - companyId: {}, name: {}", result.getId(), result.getName());
+        return result;
+    }
+
+    public Page<GetCompanyResult> getCompanies(String name, CompanyType type, UUID hubId, Pageable pageable) {
+        // name 파라미터 유무에 따라 검색/전체 조회 분기 → Repository에서 처리
+        log.debug("업체 목록 조회 - name: {}, type: {}, hubId: {}, page: {}",
+                name, type, hubId, pageable.getPageNumber());
+        return companyRepository.searchByName(name, type, hubId, pageable)
+                .map(GetCompanyResult::from);
+    }
+
+    public GetCompanyResult getCompany(UUID companyId) {
+        log.debug("업체 단건 조회 - companyId: {}", companyId);
+        return companyRepository.findByIdAndDeletedAtIsNull(companyId)
+                .map(GetCompanyResult::from)
+                .orElseThrow(() -> {
+                    log.warn("업체 조회 실패 - companyId: {}", companyId);
+                    return new BusinessException(CompanyErrorCode.COMPANY_NOT_FOUND);
+                });
+    }
+
+    @Transactional
+    public GetCompanyResult updateCompany(UpdateCompanyCommand command) {
+        log.info("업체 수정 요청 - companyId: {}, requester: {}, role: {}",
+                command.getCompanyId(), command.getRequesterId(), command.getRequesterRole());
+
+        Company company = companyRepository.findByIdAndDeletedAtIsNull(command.getCompanyId())
+                .orElseThrow(() -> {
+                    log.warn("업체 수정 실패 - 업체 없음, companyId: {}", command.getCompanyId());
+                    return new BusinessException(CompanyErrorCode.COMPANY_NOT_FOUND);
+                });
+
+        // 역할별 소유권 검증
+        validateUpdateAccess(company, command);
+
+        // hub_id 변경은 MASTER 전용
+        if (command.getHubId() != null) {
+            if (!ROLE_MASTER.equals(command.getRequesterRole())) {
+                log.warn("허브 변경 권한 없음 - requester: {}, role: {}",
+                        command.getRequesterId(), command.getRequesterRole());
+                throw new BusinessException(CompanyErrorCode.COMPANY_ACCESS_DENIED);
+            }
+            // TODO: 변경할 hub 존재 여부 검증
+            company.changeHub(command.getHubId());
+        }
+
+        company.update(command.getName(), command.getCompanyType(), command.getAddress());
+        log.info("업체 수정 완료 - companyId: {}", command.getCompanyId());
+        return GetCompanyResult.from(company);
+    }
+
+    @Transactional
+    public DeleteCompanyResult deleteCompany(UUID companyId, UUID requesterId,
+                                             String requesterRole, UUID requesterHubId) {
+        log.info("업체 삭제 요청 - companyId: {}, requester: {}, role: {}",
+                companyId, requesterId, requesterRole);
+        Company company = companyRepository.findByIdAndDeletedAtIsNull(companyId)
+                .orElseThrow(() -> {
+                    log.warn("업체 삭제 실패 - 업체 없음, companyId: {}", companyId);
+                    return new BusinessException(CompanyErrorCode.COMPANY_NOT_FOUND);
+                });
+
+        // MASTER, HUB_MANAGER만 삭제 가능 — 그 외 역할은 즉시 차단
+        if (!ROLE_MASTER.equals(requesterRole) && !ROLE_HUB_MANAGER.equals(requesterRole)) {
+            log.warn("업체 삭제 권한 없음 - requester: {}, role: {}", requesterId, requesterRole);
+            throw new BusinessException(CompanyErrorCode.COMPANY_ACCESS_DENIED);
+        }
+
+        // HUB_MANAGER는 자기 허브 업체만 삭제 가능
+        if (ROLE_HUB_MANAGER.equals(requesterRole)) {
+            if (!company.getHubId().equals(requesterHubId)) {
+                log.warn("업체 삭제 권한 없음 - 허브 불일치, requester: {}, 업체 hubId: {}, 소속 hubId: {}",
+                        requesterId, company.getHubId(), requesterHubId);
+                throw new BusinessException(CompanyErrorCode.COMPANY_HUB_MISMATCH);
+            }
+        }
+
+        company.softDelete(requesterId);
+        log.info("업체 삭제 완료 - companyId: {}, deletedBy: {}", companyId, requesterId);
+
+        // TODO: productClient.deleteByCompanyId(companyId) — 하위 product 일괄 soft delete
+        // 실패 시 부분 삭제 상태 발생 가능
+
+        return DeleteCompanyResult.of(company.getDeletedAt(), company.getDeletedBy());
+    }
+
+    // user-service 내부 API — 담당자 배정
+    @Transactional
+    public void assignManager(AssignManagerCommand command) {
+        log.info("업체담당자 배정 user-service로부터 요청 - companyId: {}, managerId: {}",
+                command.getCompanyId(), command.getManagerId());
+
+        Company company = companyRepository.findByIdAndDeletedAtIsNull(command.getCompanyId())
+                .orElseThrow(() -> {
+                    log.warn("담당자 배정 실패 - 업체 없음, companyId: {}", command.getCompanyId());
+                    return new BusinessException(CompanyErrorCode.COMPANY_NOT_FOUND);
+                });
+        company.assignManager(command.getManagerId());
+    }
+
+    /**
+     * 수정 권한 검증 내부메서드
+     * MASTER — 전체 허용
+     * HUB_MANAGER — 자기 허브 소속 업체만
+     * COMPANY_MANAGER — 자기 소속 업체만
+     */
+    private void validateUpdateAccess(Company company, UpdateCompanyCommand command) {
+        switch (command.getRequesterRole()) {
+            case ROLE_MASTER -> { /* 전체 허용 */ }
+            case ROLE_HUB_MANAGER -> {
+                if (!company.getHubId().equals(command.getRequesterHubId())) {
+                    log.warn("업체 수정 권한 없음 - 허브 불일치, requester: {}, 업체 hubId: {}, 소속 hubId: {}",
+                            command.getRequesterId(), company.getHubId(), command.getRequesterHubId());
+                    throw new BusinessException(CompanyErrorCode.COMPANY_HUB_MISMATCH);
+                }
+            }
+            case ROLE_COMPANY_MANAGER -> {
+                if (!company.getId().equals(command.getRequesterCompanyId())) {
+                    log.warn("업체 수정 권한 없음 - 업체 불일치, requester: {}, 업체 id: {}, 요청 companyId: {}",
+                            command.getRequesterId(), company.getId(), command.getRequesterCompanyId());
+                    throw new BusinessException(CompanyErrorCode.COMPANY_ACCESS_DENIED);
+                }
+            }
+            default -> {
+                log.warn("업체 수정 권한 없음 - 허용되지 않는 역할, requester: {}, role: {}",
+                        command.getRequesterId(), command.getRequesterRole());
+                throw new BusinessException(CompanyErrorCode.COMPANY_ACCESS_DENIED);
+            }
+        }
+    }
+}

--- a/company-service/src/main/java/com/sparta/lucky/company/application/dto/AssignManagerCommand.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/application/dto/AssignManagerCommand.java
@@ -1,0 +1,14 @@
+package com.sparta.lucky.company.application.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+// 내부 API — user-service가 담당자 배정 시 호출
+@Getter
+@Builder
+public class AssignManagerCommand {
+    private final UUID companyId;
+    private final UUID managerId;
+}

--- a/company-service/src/main/java/com/sparta/lucky/company/application/dto/CreateCompanyCommand.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/application/dto/CreateCompanyCommand.java
@@ -1,0 +1,22 @@
+package com.sparta.lucky.company.application.dto;
+
+import com.sparta.lucky.company.domain.CompanyType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+// Controller → Service 전달 DTO (비즈니스 명령)
+@Getter
+@Builder
+public class CreateCompanyCommand {
+    private final String name;
+    private final CompanyType companyType;
+    private final UUID hubId;
+    private final String address;
+
+    // 소유권 검증용 — Gateway 헤더에서 추출
+    private final UUID requesterId;
+    private final String requesterRole;
+    private final UUID requesterHubId;  // HUB_MANAGER: 자기 허브에만 생성 가능
+}

--- a/company-service/src/main/java/com/sparta/lucky/company/application/dto/CreateCompanyResult.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/application/dto/CreateCompanyResult.java
@@ -1,0 +1,36 @@
+package com.sparta.lucky.company.application.dto;
+
+import com.sparta.lucky.company.domain.Company;
+import com.sparta.lucky.company.domain.CompanyType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class CreateCompanyResult {
+    private final UUID id;
+    private final String name;
+    private final CompanyType companyType;
+    private final UUID hubId;
+    private final UUID manager;
+    private final String address;
+    private final LocalDateTime createdAt;
+    private final UUID createdBy;
+
+    // Entity → Result 변환 팩토리 메서드
+    public static CreateCompanyResult from(Company company) {
+        return CreateCompanyResult.builder()
+                .id(company.getId())
+                .name(company.getName())
+                .companyType(company.getCompanyType())
+                .hubId(company.getHubId())
+                .manager(company.getManager())
+                .address(company.getAddress())
+                .createdAt(company.getCreatedAt())
+                .createdBy(company.getCreatedBy())
+                .build();
+    }
+}

--- a/company-service/src/main/java/com/sparta/lucky/company/application/dto/DeleteCompanyResult.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/application/dto/DeleteCompanyResult.java
@@ -1,0 +1,21 @@
+package com.sparta.lucky.company.application.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class DeleteCompanyResult {
+    private final LocalDateTime deletedAt;
+    private final UUID deletedBy;
+
+    public static DeleteCompanyResult of(LocalDateTime deletedAt, UUID deletedBy) {
+        return DeleteCompanyResult.builder()
+                .deletedAt(deletedAt)
+                .deletedBy(deletedBy)
+                .build();
+    }
+}

--- a/company-service/src/main/java/com/sparta/lucky/company/application/dto/GetCompanyResult.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/application/dto/GetCompanyResult.java
@@ -1,0 +1,35 @@
+package com.sparta.lucky.company.application.dto;
+
+import com.sparta.lucky.company.domain.Company;
+import com.sparta.lucky.company.domain.CompanyType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class GetCompanyResult {
+    private final UUID id;
+    private final String name;
+    private final CompanyType companyType;
+    private final UUID hubId;
+    private final UUID manager;
+    private final String address;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public static GetCompanyResult from(Company company) {
+        return GetCompanyResult.builder()
+                .id(company.getId())
+                .name(company.getName())
+                .companyType(company.getCompanyType())
+                .hubId(company.getHubId())
+                .manager(company.getManager())
+                .address(company.getAddress())
+                .createdAt(company.getCreatedAt())
+                .updatedAt(company.getUpdatedAt())
+                .build();
+    }
+}

--- a/company-service/src/main/java/com/sparta/lucky/company/application/dto/UpdateCompanyCommand.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/application/dto/UpdateCompanyCommand.java
@@ -1,0 +1,26 @@
+package com.sparta.lucky.company.application.dto;
+
+import com.sparta.lucky.company.domain.CompanyType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+public class UpdateCompanyCommand {
+    private final UUID companyId;
+
+    // null이면 해당 필드 미변경
+    private final String name;
+    private final CompanyType companyType;
+    private final String address;
+    private final UUID hubId;  // MASTER만 변경 가능
+
+    // JWT 파싱 데이터는 요청자 기준 > requester로 표기합니다
+    // 소유권 검증용
+    private final UUID requesterId;
+    private final String requesterRole;
+    private final UUID requesterHubId;     // HUB_MANAGER 검증
+    private final UUID requesterCompanyId; // COMPANY_MANAGER 검증
+}

--- a/company-service/src/main/java/com/sparta/lucky/company/common/exception/ErrorCode.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/common/exception/ErrorCode.java
@@ -3,7 +3,7 @@ package com.sparta.lucky.company.common.exception;
 // 각 도메인별 에러 코드 enum이 이 인터페이스를 구현
 // 예: CompanyErrorCode implements ErrorCode
 public interface ErrorCode {
-    String getCode();       // "COMPANY_001"
-    String getMessage();    // "업체를 찾을 수 없습니다."
-    int getHttpStatus();    // 404
+    String getCode();       // ex) "COMPANY_001"
+    String getMessage();    // ex) "업체를 찾을 수 없습니다."
+    int getHttpStatus();    // ex) 404
 }

--- a/company-service/src/main/java/com/sparta/lucky/company/common/exception/GlobalExceptionHandler.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/common/exception/GlobalExceptionHandler.java
@@ -4,6 +4,8 @@ import com.sparta.lucky.company.common.response.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -38,6 +40,14 @@ public class GlobalExceptionHandler {
         String message = e.getName() + "의 값이 올바르지 않습니다: " + e.getValue();
         return ResponseEntity.badRequest()
                 .body(ApiResponse.error("VALIDATION_002", message));
+    }
+
+    // 헤더 누락 (MissingRequestHeaderException) / 요청 바디 파싱 실패 (HttpMessageNotReadableException) - 400
+    @ExceptionHandler({MissingRequestHeaderException.class, HttpMessageNotReadableException.class})
+    public ResponseEntity<ApiResponse<Void>> handleBadRequest(Exception e) {
+        log.warn("[BadRequest] {}", e.getMessage());
+        return ResponseEntity.badRequest()
+                .body(ApiResponse.error("VALIDATION_003", "요청 형식이 올바르지 않습니다."));
     }
 
     // 그 외 예상치 못한 서버 에러

--- a/company-service/src/main/java/com/sparta/lucky/company/common/exception/GlobalExceptionHandler.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,50 @@
+package com.sparta.lucky.company.common.exception;
+
+import com.sparta.lucky.company.common.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 비즈니스 예외 (404 조회 결과 없음, 403 권한 없음 등)
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
+        log.warn("[BusinessException] code={}, message={}", e.getErrorCode(), e.getMessage());
+        return ResponseEntity
+                .status(e.getHttpStatus())
+                .body(ApiResponse.error(e.getErrorCode(), e.getMessage()));
+    }
+
+    // @Valid 유효성 검증 실패
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidation(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
+                .findFirst()
+                .orElse("유효성 검증 실패");
+        return ResponseEntity.badRequest()
+                .body(ApiResponse.error("VALIDATION_001", message));
+    }
+
+    // Enum, UUID 등 타입 변환 실패 (@RequestParam, @PathVariable)
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<Void>> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
+        String message = e.getName() + "의 값이 올바르지 않습니다: " + e.getValue();
+        return ResponseEntity.badRequest()
+                .body(ApiResponse.error("VALIDATION_002", message));
+    }
+
+    // 그 외 예상치 못한 서버 에러
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("[Unexpected Error]", e);
+        return ResponseEntity.internalServerError()
+                .body(ApiResponse.error("INTERNAL_001", "서버 오류가 발생했습니다."));
+    }
+}

--- a/company-service/src/main/java/com/sparta/lucky/company/domain/Company.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/domain/Company.java
@@ -1,0 +1,67 @@
+package com.sparta.lucky.company.domain;
+
+import com.sparta.lucky.company.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_company")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class Company extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(columnDefinition = "uuid")
+    private UUID id;
+
+    @Column(name = "name", length = 100, nullable = false)
+    private String name;
+
+    // DB에 "SUPPLIER" / "RECEIVER" 문자열로 저장
+    @Enumerated(EnumType.STRING)
+    @Column(name = "company_type", length = 10, nullable = false)
+    private CompanyType companyType;
+
+    // Cross-service FK 금지 — UUID 값만 저장, 무결성은 FeignClient로 검증
+    @Column(name = "hub_id", nullable = false, columnDefinition = "uuid")
+    private UUID hubId;
+
+    // MASTER가 user-service 내부 API로 나중에 배정 → 생성 시 NULL 허용
+    @Column(name = "manager", columnDefinition = "uuid")
+    private UUID manager;
+
+    @Column(name = "address", length = 255, nullable = false)
+    private String address;
+
+    // 도메인 메서드
+
+    /**
+     * 기본 정보 수정 (MASTER, HUB_MANAGER, COMPANY_MANAGER 공통)
+     * null 값은 무시 — 전달된 필드만 업데이트
+     */
+    public void update(String name, CompanyType companyType, String address) {
+        if (name != null) this.name = name;
+        if (companyType != null) this.companyType = companyType;
+        if (address != null) this.address = address;
+    }
+
+    /**
+     * 허브 변경 — MASTER 전용
+     * hub_id 변경 시 product/product_stock의 hub_id는 동기화되지 않음
+     */
+    public void changeHub(UUID newHubId) {
+        this.hubId = newHubId;
+    }
+
+    /**
+     * 담당자 배정 — user-service가 내부 API로 호출
+     */
+    public void assignManager(UUID managerId) {
+        this.manager = managerId;
+    }
+}

--- a/company-service/src/main/java/com/sparta/lucky/company/domain/Company.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/domain/Company.java
@@ -3,6 +3,7 @@ package com.sparta.lucky.company.domain;
 import com.sparta.lucky.company.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import java.util.Objects;
 
 import java.util.UUID;
 
@@ -55,7 +56,8 @@ public class Company extends BaseEntity {
      * hub_id 변경 시 product/product_stock의 hub_id는 동기화되지 않음
      */
     public void changeHub(UUID newHubId) {
-        this.hubId = newHubId;
+        // null이 들어오면 DB 저장 시점에 실패하지 않고 즉시 실패로 수정
+        this.hubId = Objects.requireNonNull(newHubId, "newHubId 값 누락");
     }
 
     /**

--- a/company-service/src/main/java/com/sparta/lucky/company/domain/CompanyErrorCode.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/domain/CompanyErrorCode.java
@@ -1,0 +1,19 @@
+package com.sparta.lucky.company.domain;
+
+import com.sparta.lucky.company.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CompanyErrorCode implements ErrorCode {
+
+    COMPANY_NOT_FOUND("COMPANY_001", "업체를 찾을 수 없습니다.", 404),
+    COMPANY_ACCESS_DENIED("COMPANY_002", "해당 업체에 접근 권한이 없습니다.", 403),
+    COMPANY_HUB_MISMATCH("COMPANY_003", "허브 관리자는 소속 허브의 업체만 관리할 수 있습니다.", 403),
+    COMPANY_ALREADY_DELETED("COMPANY_004", "이미 삭제된 업체입니다.", 409);
+
+    private final String code;
+    private final String message;
+    private final int httpStatus;
+}

--- a/company-service/src/main/java/com/sparta/lucky/company/domain/CompanyRepository.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/domain/CompanyRepository.java
@@ -1,0 +1,18 @@
+package com.sparta.lucky.company.domain;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+import java.util.UUID;
+
+// Application 레이어가 의존하는 인터페이스 (DIP 적용)
+// JPA 구현체는 infrastructure 레이어에 위치
+public interface CompanyRepository {
+
+    Company save(Company company);
+
+    Optional<Company> findByIdAndDeletedAtIsNull(UUID id);
+
+    Page<Company> searchByName(String name, CompanyType type, UUID hubId, Pageable pageable);
+}

--- a/company-service/src/main/java/com/sparta/lucky/company/domain/CompanyType.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/domain/CompanyType.java
@@ -1,0 +1,6 @@
+package com.sparta.lucky.company.domain;
+
+public enum CompanyType {
+    SUPPLIER,  // 생산업체 — 물건을 보내는 쪽 (requester_company)
+    RECEIVER   // 수령업체 — 물건을 받는 쪽 (receiver_company)
+}

--- a/company-service/src/main/java/com/sparta/lucky/company/infrastructure/CompanyJpaRepository.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/infrastructure/CompanyJpaRepository.java
@@ -1,0 +1,30 @@
+package com.sparta.lucky.company.infrastructure;
+
+import com.sparta.lucky.company.domain.Company;
+import com.sparta.lucky.company.domain.CompanyType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+import java.util.UUID;
+
+// Spring Data JPA — 쿼리 메서드 네이밍 사용
+interface CompanyJpaRepository extends JpaRepository<Company, UUID> {
+
+    Optional<Company> findByIdAndDeletedAtIsNull(UUID id);
+
+    @Query("SELECT c FROM Company c WHERE " +
+            "(:name IS NULL OR c.name LIKE %:name%) AND " +
+            "(:type IS NULL OR c.companyType = :type) AND " +
+            "(:hubId IS NULL OR c.hubId = :hubId) AND " +
+            "c.deletedAt IS NULL")
+    Page<Company> findAllByConditions(
+            @Param("name") String name,
+            @Param("type") CompanyType type,
+            @Param("hubId") UUID hubId,
+            Pageable pageable
+    );
+}

--- a/company-service/src/main/java/com/sparta/lucky/company/infrastructure/CompanyRepositoryImpl.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/infrastructure/CompanyRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.sparta.lucky.company.infrastructure;
+
+import com.sparta.lucky.company.domain.Company;
+import com.sparta.lucky.company.domain.CompanyRepository;
+import com.sparta.lucky.company.domain.CompanyType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+// Domain 인터페이스 구현체 — JpaRepository를 감싸서 Application에 노출
+@Repository
+@RequiredArgsConstructor
+public class CompanyRepositoryImpl implements CompanyRepository {
+
+    private final CompanyJpaRepository jpaRepository;
+
+    @Override
+    public Company save(Company company) {
+        return jpaRepository.save(company);
+    }
+
+    @Override
+    public Optional<Company> findByIdAndDeletedAtIsNull(UUID id) {
+        return jpaRepository.findByIdAndDeletedAtIsNull(id);
+    }
+
+    @Override
+    public Page<Company> searchByName(String name, CompanyType type, UUID hubId, Pageable pageable) {
+        return jpaRepository.findAllByConditions(name, type, hubId, pageable);
+    }
+
+
+}

--- a/company-service/src/main/java/com/sparta/lucky/company/presentation/CompanyController.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/presentation/CompanyController.java
@@ -159,7 +159,7 @@ public class CompanyController {
     }
 
     /**
-     * 업제 삭제
+     * 업체 삭제
      * [권한]
      * MASTER - 모두 가능
      * HUB_MANAGER - 담당 허브 업체만 가능

--- a/company-service/src/main/java/com/sparta/lucky/company/presentation/CompanyController.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/presentation/CompanyController.java
@@ -1,0 +1,185 @@
+package com.sparta.lucky.company.presentation;
+
+import com.sparta.lucky.company.application.CompanyService;
+import com.sparta.lucky.company.application.dto.CreateCompanyCommand;
+import com.sparta.lucky.company.application.dto.UpdateCompanyCommand;
+import com.sparta.lucky.company.common.response.ApiResponse;
+import com.sparta.lucky.company.domain.CompanyType;
+import com.sparta.lucky.company.presentation.dto.*;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 외부 API 담당 컨트롤러
+ * @RequestHeader("X-User-Id") UUID userId : Gateway가 JWt에서 파싱한 요청자 UUID
+ * @RequestHeader("X-User-Role") String userRole : JWT 파싱한 요청자 role
+ * @RequestHeader("X-Hub-Id") UUID hubId : JWT 파싱 요청자 hubId
+ * @RequestHeader("X-Company-Id") UUID companyId : JWT 파싱 요청자 companyId
+ */
+
+@RestController
+@RequestMapping("/api/v1/companies")
+@RequiredArgsConstructor
+public class CompanyController {
+
+    private final CompanyService companyService;
+
+    /**
+     * 업체 생성
+     * [권한]
+     * - MASTER는 모든 허브 업체 생성 가능
+     * - HUB_MANAGER는 자신의 소속 허브 업체만 생성 가능
+     *
+     * @param reqDto 업체 생성 요청 (name, companyType, hubId, address)
+     * @param userId 요청자 UUID
+     * @param userRole 요청자 role
+     * @param hubId HUB_MANAGER의 담당 허브 UUID (MASTER는 null)
+     * @return 생성된 업체 데이터
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<PostCompanyResDto> createCompany(
+            @Valid @RequestBody PostCompanyReqDto reqDto,
+            // Gateway가 JWT 파싱 후 주입하는 헤더들
+            @RequestHeader("X-User-Id") UUID userId,
+            @RequestHeader("X-User-Role") String userRole,
+            @RequestHeader(value = "X-Hub-Id", required = false) UUID hubId
+    ) {
+        // command로 감싸서 service에 전달 (Http 종속성 제거)
+        CreateCompanyCommand command = CreateCompanyCommand.builder()
+                .name(reqDto.getName())
+                .companyType(reqDto.getCompanyType())
+                .hubId(reqDto.getHubId())
+                .address(reqDto.getAddress())
+                .requesterId(userId)
+                .requesterRole(userRole)
+                .requesterHubId(hubId)
+                .build();
+
+        return ApiResponse.success(
+                PostCompanyResDto.from(companyService.createCompany(command))
+        );
+    }
+
+
+    /**
+     * 업체 목록 조회 / 검색
+     * [권한]
+     * - 모든 로그인 사용자 가능
+     *
+     * @param name 업체명 검색어 (생략시 전체 조회)
+     * @param type 업체유형 (SUPPLIER / RECEIVER)
+     * @param hubId 업체 소속 허브 UUID
+     * @param pageable 페이지네이션 (기본값 size = 10, createdAt DESC)
+     * @return 업체 목록 페이지
+     */
+    @GetMapping
+    public ApiResponse<Page<GetCompanyResDto>> getCompanies(
+            @RequestParam(required = false) String name,
+            @RequestParam(required = false) CompanyType type,
+            @RequestParam(required = false) UUID hubId,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        // size 유효성 검사 : 10/30/50 외 값은 10으로 고정
+        int validSize = List.of(10,30,50).contains(pageable.getPageSize())
+                ? pageable.getPageSize() : 10;
+
+        Pageable validPageable = PageRequest.of(
+                pageable.getPageNumber(), validSize, pageable.getSort()
+        );
+
+        return ApiResponse.success(
+                companyService.getCompanies(name, type, hubId, validPageable).map(GetCompanyResDto::from)
+        );
+    }
+
+    /**
+     * 업체 단건 조회
+     * [권한]
+     * - 모든 로그인 사용자 가능
+     * @param companyId
+     * @return
+     */
+    @GetMapping("/{companyId}")
+    public ApiResponse<GetCompanyResDto> getCompany(@PathVariable UUID companyId) {
+        return ApiResponse.success(
+                GetCompanyResDto.from(companyService.getCompany(companyId))
+        );
+    }
+
+    /**
+     * 업체 수정
+     * [권한]
+     * MASTER - 모두 가능
+     * HUB_MANAGER - 담당 허브 업체만 가능
+     * COMPANY-MANAGER - 본인 업체만 가능
+     *
+     * @param companyId
+     * @param reqDto 업체 수정 요청
+     * @param userId
+     * @param userRole
+     * @param hubId
+     * @param companyIdHeader
+     * @return 수정된 업체 결과
+     */
+    @PatchMapping("/{companyId}")
+    public ApiResponse<GetCompanyResDto> updateCompany(
+            @PathVariable UUID companyId,
+            @Valid @RequestBody PatchCompanyReqDto reqDto,
+            @RequestHeader("X-User-Id") UUID userId,
+            @RequestHeader("X-User-Role") String userRole,
+            @RequestHeader(value = "X-Hub-Id", required = false) UUID hubId,
+            @RequestHeader(value = "X-Company-Id", required = false) UUID companyIdHeader
+    ) {
+        UpdateCompanyCommand command = UpdateCompanyCommand.builder()
+                .companyId(companyId)
+                .name(reqDto.getName())
+                .companyType(reqDto.getCompanyType())
+                .hubId(reqDto.getHubId())
+                .address(reqDto.getAddress())
+                .requesterId(userId)
+                .requesterRole(userRole)
+                .requesterHubId(hubId)
+                .requesterCompanyId(companyIdHeader)
+                .build();
+
+        return ApiResponse.success(
+                GetCompanyResDto.from(companyService.updateCompany(command))
+        );
+    }
+
+    /**
+     * 업제 삭제
+     * [권한]
+     * MASTER - 모두 가능
+     * HUB_MANAGER - 담당 허브 업체만 가능
+     * @param companyId
+     * @param userId
+     * @param userRole
+     * @param hubId
+     * @return 삭제 결과
+     */
+    @DeleteMapping("/{companyId}")
+    public ApiResponse<DeleteCompanyResDto> deleteCompany(
+            @PathVariable UUID companyId,
+            @RequestHeader("X-User-Id") UUID userId,
+            @RequestHeader("X-User-Role") String userRole,
+            @RequestHeader(value = "X-Hub-Id", required = false) UUID hubId
+    ) {
+        return ApiResponse.success(
+                DeleteCompanyResDto.from(
+                        companyService.deleteCompany(companyId, userId, userRole, hubId)
+                )
+        );
+    }
+}

--- a/company-service/src/main/java/com/sparta/lucky/company/presentation/CompanyInternalController.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/presentation/CompanyInternalController.java
@@ -1,0 +1,52 @@
+package com.sparta.lucky.company.presentation;
+
+import com.sparta.lucky.company.common.response.ApiResponse;
+import com.sparta.lucky.company.application.CompanyService;
+import com.sparta.lucky.company.application.dto.AssignManagerCommand;
+import com.sparta.lucky.company.presentation.dto.GetCompanyResDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+// 서비스 간 내부 호출 전용 — X-Internal-Request 헤더 필수
+@RestController
+@RequestMapping("/internal/api/v1/companies")
+@RequiredArgsConstructor
+public class CompanyInternalController {
+
+    private final CompanyService companyService;
+
+    // order-service, product-service, user-service가 업체 검증 시 사용
+    @GetMapping("/{companyId}")
+    public ApiResponse<GetCompanyResDto> getCompany(
+            @PathVariable UUID companyId,
+            @RequestHeader("X-Internal-Request") String internalFlag  // 내부 요청 식별
+    ) {
+        return ApiResponse.success(
+                GetCompanyResDto.from(companyService.getCompany(companyId))
+        );
+    }
+
+    // user-service가 COMPANY_MANAGER 배정 시 호출
+    @PatchMapping("/{companyId}/manager")
+    public ApiResponse<Void> assignManager(
+            @PathVariable UUID companyId,
+            @RequestBody AssignManagerReqBody body,
+            @RequestHeader("X-Internal-Request") String internalFlag
+    ) {
+        companyService.assignManager(
+                AssignManagerCommand.builder()
+                        .companyId(companyId)
+                        .managerId(body.getManagerId())
+                        .build()
+        );
+        return ApiResponse.success();
+    }
+
+    // 내부 API 전용 Request Body (Presentation 레이어 내부 static 클래스로 관리)
+    @lombok.Getter
+    static class AssignManagerReqBody {
+        private UUID managerId;
+    }
+}

--- a/company-service/src/main/java/com/sparta/lucky/company/presentation/CompanyInternalController.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/presentation/CompanyInternalController.java
@@ -6,6 +6,8 @@ import com.sparta.lucky.company.application.dto.AssignManagerCommand;
 import com.sparta.lucky.company.presentation.dto.GetCompanyResDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 
 import java.util.UUID;
 
@@ -32,9 +34,9 @@ public class CompanyInternalController {
     @PatchMapping("/{companyId}/manager")
     public ApiResponse<Void> assignManager(
             @PathVariable UUID companyId,
-            @RequestBody AssignManagerReqBody body,
+            @Valid @RequestBody AssignManagerReqBody body,  // @Valid 추가
             @RequestHeader("X-Internal-Request") String internalFlag
-    ) {
+    )  {
         companyService.assignManager(
                 AssignManagerCommand.builder()
                         .companyId(companyId)
@@ -47,6 +49,7 @@ public class CompanyInternalController {
     // 내부 API 전용 Request Body (Presentation 레이어 내부 static 클래스로 관리)
     @lombok.Getter
     static class AssignManagerReqBody {
+        @NotNull(message = "managerId는 필수입니다.")  // null이면 400 반환
         private UUID managerId;
     }
 }

--- a/company-service/src/main/java/com/sparta/lucky/company/presentation/dto/DeleteCompanyResDto.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/presentation/dto/DeleteCompanyResDto.java
@@ -1,0 +1,22 @@
+package com.sparta.lucky.company.presentation.dto;
+
+import com.sparta.lucky.company.application.dto.DeleteCompanyResult;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class DeleteCompanyResDto {
+    private final LocalDateTime deletedAt;
+    private final UUID deletedBy;
+
+    public static DeleteCompanyResDto from(DeleteCompanyResult result) {
+        return DeleteCompanyResDto.builder()
+                .deletedAt(result.getDeletedAt())
+                .deletedBy(result.getDeletedBy())
+                .build();
+    }
+}

--- a/company-service/src/main/java/com/sparta/lucky/company/presentation/dto/GetCompanyResDto.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/presentation/dto/GetCompanyResDto.java
@@ -1,0 +1,35 @@
+package com.sparta.lucky.company.presentation.dto;
+
+import com.sparta.lucky.company.application.dto.GetCompanyResult;
+import com.sparta.lucky.company.domain.CompanyType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class GetCompanyResDto {
+    private final UUID id;
+    private final String name;
+    private final CompanyType companyType;
+    private final UUID hubId;
+    private final UUID manager;
+    private final String address;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public static GetCompanyResDto from(GetCompanyResult result) {
+        return GetCompanyResDto.builder()
+                .id(result.getId())
+                .name(result.getName())
+                .companyType(result.getCompanyType())
+                .hubId(result.getHubId())
+                .manager(result.getManager())
+                .address(result.getAddress())
+                .createdAt(result.getCreatedAt())
+                .updatedAt(result.getUpdatedAt())
+                .build();
+    }
+}

--- a/company-service/src/main/java/com/sparta/lucky/company/presentation/dto/PatchCompanyReqDto.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/presentation/dto/PatchCompanyReqDto.java
@@ -1,0 +1,22 @@
+package com.sparta.lucky.company.presentation.dto;
+
+import com.sparta.lucky.company.domain.CompanyType;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+import java.util.UUID;
+
+// 모든 필드 optional — null이면 해당 필드 미수정
+@Getter
+public class PatchCompanyReqDto {
+
+    @Size(max = 100, message = "업체명은 100자 이하여야 합니다.")
+    private String name;
+
+    private CompanyType companyType;
+
+    private UUID hubId;  // MASTER만 변경 가능 (Service에서 검증)
+
+    @Size(max = 255, message = "주소는 255자 이하여야 합니다.")
+    private String address;
+}

--- a/company-service/src/main/java/com/sparta/lucky/company/presentation/dto/PostCompanyReqDto.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/presentation/dto/PostCompanyReqDto.java
@@ -1,0 +1,27 @@
+package com.sparta.lucky.company.presentation.dto;
+
+import com.sparta.lucky.company.domain.CompanyType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class PostCompanyReqDto {
+
+    @NotBlank(message = "업체명은 필수 항목입니다.")
+    @Size(max = 100, message = "업체명은 100자 이하여야 합니다.")
+    private String name;
+
+    @NotNull(message = "업체 유형은 필수 항목입니다.")
+    private CompanyType companyType;
+
+    @NotNull(message = "소속 허브 ID는 필수 항목입니다.")
+    private UUID hubId;
+
+    @NotBlank(message = "주소는 필수 항목입니다.")
+    @Size(max = 255, message = "주소는 255자 이하여야 합니다.")
+    private String address;
+}

--- a/company-service/src/main/java/com/sparta/lucky/company/presentation/dto/PostCompanyResDto.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/presentation/dto/PostCompanyResDto.java
@@ -1,0 +1,35 @@
+package com.sparta.lucky.company.presentation.dto;
+
+import com.sparta.lucky.company.application.dto.CreateCompanyResult;
+import com.sparta.lucky.company.domain.CompanyType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class PostCompanyResDto {
+    private final UUID id;
+    private final String name;
+    private final CompanyType companyType;
+    private final UUID hubId;
+    private final UUID manager;
+    private final String address;
+    private final LocalDateTime createdAt;
+    private final UUID createdBy;
+
+    public static PostCompanyResDto from(CreateCompanyResult result) {
+        return PostCompanyResDto.builder()
+                .id(result.getId())
+                .name(result.getName())
+                .companyType(result.getCompanyType())
+                .hubId(result.getHubId())
+                .manager(result.getManager())
+                .address(result.getAddress())
+                .createdAt(result.getCreatedAt())
+                .createdBy(result.getCreatedBy())
+                .build();
+    }
+}

--- a/company-service/src/main/resources/application-local.yaml
+++ b/company-service/src/main/resources/application-local.yaml
@@ -1,4 +1,4 @@
-#application-loacl.yaml
+#application-local.yaml
 
 server:
   port: 19300
@@ -7,13 +7,12 @@ spring:
   application:
     name: company-service
   datasource:
-    url: jdbc:postgresql://localhost:5432/lucky_logistics?currentSchema=company_schema
-    username: lucky
-    password: lucky7777
+    url: jdbc:postgresql://${POSTGRES_HOST:localhost}:${POSTGRES_PORT:5432}/${POSTGRES_DB:lucky_logistics}?currentSchema=${COMPANY_SERVICE_SCHEMA:company_schema}
+    username: ${POSTGRES_USER:lucky}
+    password: ${POSTGRES_PASSWORD:lucky7777}
   jpa:
     hibernate:
       ddl-auto: create
-      # 재시작마다 초기화
 
 # 로깅 설정
 logging:

--- a/company-service/src/main/resources/application-local.yaml
+++ b/company-service/src/main/resources/application-local.yaml
@@ -1,0 +1,28 @@
+#application-loacl.yaml
+
+server:
+  port: 19300
+
+spring:
+  application:
+    name: company-service
+  datasource:
+    url: jdbc:postgresql://localhost:5432/lucky_logistics?currentSchema=company_schema
+    username: lucky
+    password: lucky7777
+  jpa:
+    hibernate:
+      ddl-auto: create
+      # 재시작마다 초기화
+
+# 로깅 설정
+logging:
+  level:
+    com.sparta.lucky.company: DEBUG # 본 패키지
+    org.hibernate.SQL: DEBUG # SQL 쿼리 출력
+    org.hibernate.jdbc.bind: TRACE # 바인딩 파라미터
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:19090/eureka

--- a/company-service/src/test/java/com/sparta/lucky/company/application/CompanyServiceTest.java
+++ b/company-service/src/test/java/com/sparta/lucky/company/application/CompanyServiceTest.java
@@ -1,6 +1,7 @@
 package com.sparta.lucky.company.application;
 
 import com.sparta.lucky.company.application.dto.CreateCompanyCommand;
+import com.sparta.lucky.company.application.dto.CreateCompanyResult;
 import com.sparta.lucky.company.application.dto.UpdateCompanyCommand;
 import com.sparta.lucky.company.common.exception.BusinessException;
 import com.sparta.lucky.company.domain.Company;
@@ -15,11 +16,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Primary;
-import org.springframework.data.domain.AuditorAware;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -47,21 +43,10 @@ class CompanyServiceTest {
     @Mock
     private CompanyRepository companyRepository;
 
-    // 테스트용 AuditorAware - AuditConfig의 빈을 덮어씀
-    @TestConfiguration
-    @EnableJpaAuditing
-    static class TestAuditConfig {
-        @Bean
-        @Primary
-        public AuditorAware<UUID> auditorAware() {
-            return () -> Optional.of(UUID.fromString("00000000-0000-0000-0000-000000000001"));
-        }
-    }
-
     // 테스트용 고정 UUID
-    private static final UUID COMPANY_ID   = UUID.randomUUID();
-    private static final UUID HUB_A        = UUID.randomUUID();
-    private static final UUID HUB_B        = UUID.randomUUID();
+    private static final UUID COMPANY_ID = UUID.randomUUID();
+    private static final UUID HUB_A = UUID.randomUUID();
+    private static final UUID HUB_B = UUID.randomUUID();
     private static final UUID REQUESTER_ID = UUID.randomUUID();
 
     // 테스트마다 재사용할 기본 업체 엔티티
@@ -86,7 +71,7 @@ class CompanyServiceTest {
         @Test
         @DisplayName("MASTER는 어떤 허브에도 업체 생성 가능")
         void master_canCreateInAnyHub() {
-            //given
+            // given
             CreateCompanyCommand command = CreateCompanyCommand.builder()
                     .name("테스트업체")
                     .companyType(CompanyType.SUPPLIER)
@@ -98,10 +83,12 @@ class CompanyServiceTest {
                     .build();
             given(companyRepository.save(any())).willReturn(company);
 
-            //when & then - 예외 없이 실행
-            assertThatCode(() -> companyService.createCompany(command))
-                    .doesNotThrowAnyException();
+            // when
+            CreateCompanyResult result = companyService.createCompany(command);
 
+            // then — 반환값 검증
+            assertThat(result).isNotNull();
+            assertThat(result.getName()).isEqualTo("테스트업체");
         }
 
         @Test
@@ -112,12 +99,16 @@ class CompanyServiceTest {
                     .name("테스트업체").companyType(CompanyType.SUPPLIER)
                     .hubId(HUB_A).address("주소")
                     .requesterId(REQUESTER_ID).requesterRole("HUB_MANAGER")
-                    .requesterHubId(HUB_A) // 올바른 허브
+                    .requesterHubId(HUB_A)
                     .build();
             given(companyRepository.save(any())).willReturn(company);
 
-            assertThatCode(() -> companyService.createCompany(command))
-                    .doesNotThrowAnyException();
+            // when
+            CreateCompanyResult result = companyService.createCompany(command);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getHubId()).isEqualTo(HUB_A);
         }
 
         @Test

--- a/company-service/src/test/java/com/sparta/lucky/company/application/CompanyServiceTest.java
+++ b/company-service/src/test/java/com/sparta/lucky/company/application/CompanyServiceTest.java
@@ -1,0 +1,314 @@
+package com.sparta.lucky.company.application;
+
+import com.sparta.lucky.company.application.dto.CreateCompanyCommand;
+import com.sparta.lucky.company.application.dto.UpdateCompanyCommand;
+import com.sparta.lucky.company.common.exception.BusinessException;
+import com.sparta.lucky.company.domain.Company;
+import com.sparta.lucky.company.domain.CompanyErrorCode;
+import com.sparta.lucky.company.domain.CompanyRepository;
+import com.sparta.lucky.company.domain.CompanyType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * 2026-03-31 박동진
+ * CRUD중 업체 생성, 업체 수정, 업체 삭제 테스트 코드
+ * 업체 단건 조회 - 프레임워크가 검증하므로 패스
+ * 업체 목록 조회 - 서비스레이어에서는 Repository에 위임만 하는 형태로, @DataJpaTest에서 진행해야함
+ *
+ */
+
+@ExtendWith(MockitoExtension.class)
+class CompanyServiceTest {
+
+    @InjectMocks
+    private CompanyService companyService;
+
+    @Mock
+    private CompanyRepository companyRepository;
+
+    // 테스트용 AuditorAware - AuditConfig의 빈을 덮어씀
+    @TestConfiguration
+    @EnableJpaAuditing
+    static class TestAuditConfig {
+        @Bean
+        @Primary
+        public AuditorAware<UUID> auditorAware() {
+            return () -> Optional.of(UUID.fromString("00000000-0000-0000-0000-000000000001"));
+        }
+    }
+
+    // 테스트용 고정 UUID
+    private static final UUID COMPANY_ID   = UUID.randomUUID();
+    private static final UUID HUB_A        = UUID.randomUUID();
+    private static final UUID HUB_B        = UUID.randomUUID();
+    private static final UUID REQUESTER_ID = UUID.randomUUID();
+
+    // 테스트마다 재사용할 기본 업체 엔티티
+    private Company company;
+
+    @BeforeEach
+    void setUp() {
+        company = Company.builder()
+                .id(COMPANY_ID)
+                .name("테스트업체")
+                .companyType(CompanyType.SUPPLIER)
+                .hubId(HUB_A)
+                .address("서울시 강남구 1번길")
+                .build();
+    }
+
+    // createCompany
+    @Nested
+    @DisplayName("업체 생성")
+    class CreateCompany {
+
+        @Test
+        @DisplayName("MASTER는 어떤 허브에도 업체 생성 가능")
+        void master_canCreateInAnyHub() {
+            //given
+            CreateCompanyCommand command = CreateCompanyCommand.builder()
+                    .name("테스트업체")
+                    .companyType(CompanyType.SUPPLIER)
+                    .hubId(HUB_A)
+                    .address("서울시 종로구 가1길")
+                    .requesterId(REQUESTER_ID)
+                    .requesterRole("MASTER")
+                    .requesterHubId(null)
+                    .build();
+            given(companyRepository.save(any())).willReturn(company);
+
+            //when & then - 예외 없이 실행
+            assertThatCode(() -> companyService.createCompany(command))
+                    .doesNotThrowAnyException();
+
+        }
+
+        @Test
+        @DisplayName("HUB_MANAGER가 자신의 허브에 업체 생성 성공")
+        void hubManager_canCreateInOwnHub() {
+            // given
+            CreateCompanyCommand command = CreateCompanyCommand.builder()
+                    .name("테스트업체").companyType(CompanyType.SUPPLIER)
+                    .hubId(HUB_A).address("주소")
+                    .requesterId(REQUESTER_ID).requesterRole("HUB_MANAGER")
+                    .requesterHubId(HUB_A) // 올바른 허브
+                    .build();
+            given(companyRepository.save(any())).willReturn(company);
+
+            assertThatCode(() -> companyService.createCompany(command))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("HUB_MANAGER가 다른 허브에 업체 생성 시 예외")
+        void hubManager_cannotCreateInOtherHub() {
+            // given
+            CreateCompanyCommand command = CreateCompanyCommand.builder()
+                    .name("테스트업체").companyType(CompanyType.SUPPLIER)
+                    .hubId(HUB_A).address("주소")
+                    .requesterId(REQUESTER_ID).requesterRole("HUB_MANAGER")
+                    .requesterHubId(HUB_B) // 다른 허브 — 불일치
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> companyService.createCompany(command))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(CompanyErrorCode.COMPANY_HUB_MISMATCH.getCode()));
+        }
+    }
+
+    //updateCompany
+    @Nested
+    @DisplayName("업체 수정")
+    class UpdateCompany {
+
+        @Test
+        @DisplayName("MASTER는 모든 업체 수정 가능")
+        void master_canUpdateAnyCompany() {
+            // given
+            given(companyRepository.findByIdAndDeletedAtIsNull(COMPANY_ID))
+                    .willReturn(Optional.of(company));
+            UpdateCompanyCommand command = updateCommand("MASTER", HUB_A, COMPANY_ID);
+
+            assertThatCode(() -> companyService.updateCompany(command))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("HUB_MANAGER는 자신의 허브 업체 수정 가능")
+        void hubManager_canUpdateOwnHubCompany() {
+            given(companyRepository.findByIdAndDeletedAtIsNull(COMPANY_ID))
+                    .willReturn(Optional.of(company)); // company.hubId = HUB_A
+            UpdateCompanyCommand command = updateCommand("HUB_MANAGER", HUB_A, null);
+
+            assertThatCode(() -> companyService.updateCompany(command))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("HUB_MANAGER가 다른 허브 업체 수정 시 예외 발생")
+        void hubManager_cannotUpdateOtherHubCompany() {
+            given(companyRepository.findByIdAndDeletedAtIsNull(COMPANY_ID))
+                    .willReturn(Optional.of(company)); // company.hubId = HUB_A
+            UpdateCompanyCommand command = updateCommand("HUB_MANAGER", HUB_B, null); // HUB_B — 불일치
+
+            assertThatThrownBy(() -> companyService.updateCompany(command))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(CompanyErrorCode.COMPANY_HUB_MISMATCH.getCode()));
+        }
+
+        @Test
+        @DisplayName("COMPANY_MANAGER는 자신의 업체 수정 가능")
+        void companyManager_canUpdateOwnCompany() {
+            given(companyRepository.findByIdAndDeletedAtIsNull(COMPANY_ID))
+                    .willReturn(Optional.of(company));
+            UpdateCompanyCommand command = updateCommand("COMPANY_MANAGER", null, COMPANY_ID);
+
+            assertThatCode(() -> companyService.updateCompany(command))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("COMPANY_MANAGER가 타 업체 수정 시 예외 발생")
+        void companyManager_cannotUpdateOtherCompany() {
+            given(companyRepository.findByIdAndDeletedAtIsNull(COMPANY_ID))
+                    .willReturn(Optional.of(company));
+            UpdateCompanyCommand command = updateCommand("COMPANY_MANAGER", null, UUID.randomUUID()); // 다른 업체 ID
+
+            assertThatThrownBy(() -> companyService.updateCompany(command))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(CompanyErrorCode.COMPANY_ACCESS_DENIED.getCode()));
+        }
+
+        @Test
+        @DisplayName("MASTER가 아닌 역할이 hubId 변경 시 예외 발생")
+        void nonMaster_cannotChangeHubId() {
+            given(companyRepository.findByIdAndDeletedAtIsNull(COMPANY_ID))
+                    .willReturn(Optional.of(company));
+
+            // HUB_MANAGER가 hubId 변경 시도
+            UpdateCompanyCommand command = UpdateCompanyCommand.builder()
+                    .companyId(COMPANY_ID)
+                    .hubId(HUB_B) // hubId 변경 시도
+                    .requesterId(REQUESTER_ID)
+                    .requesterRole("HUB_MANAGER")
+                    .requesterHubId(HUB_A)
+                    .build();
+
+            assertThatThrownBy(() -> companyService.updateCompany(command))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(CompanyErrorCode.COMPANY_ACCESS_DENIED.getCode()));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 업체 수정 시 예외 발생")
+        void updateNotFound() {
+            given(companyRepository.findByIdAndDeletedAtIsNull(COMPANY_ID))
+                    .willReturn(Optional.empty());
+            UpdateCompanyCommand command = updateCommand("MASTER", null, null);
+
+            assertThatThrownBy(() -> companyService.updateCompany(command))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(CompanyErrorCode.COMPANY_NOT_FOUND.getCode()));
+        }
+    }
+
+    // deleteCompany
+    @Nested
+    @DisplayName("업체 삭제")
+    class DeleteCompany {
+
+        @Test
+        @DisplayName("MASTER는 모든 업체 삭제 가능")
+        void master_canDeleteAnyCompany() {
+            given(companyRepository.findByIdAndDeletedAtIsNull(COMPANY_ID))
+                    .willReturn(Optional.of(company));
+
+            assertThatCode(() -> companyService.deleteCompany(COMPANY_ID, REQUESTER_ID, "MASTER", null))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("HUB_MANAGER는 자신의 허브 업체 삭제 가능")
+        void hubManager_canDeleteOwnHubCompany() {
+            given(companyRepository.findByIdAndDeletedAtIsNull(COMPANY_ID))
+                    .willReturn(Optional.of(company)); // company.hubId = HUB_A
+
+            assertThatCode(() -> companyService.deleteCompany(COMPANY_ID, REQUESTER_ID, "HUB_MANAGER", HUB_A))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("HUB_MANAGER가 다른 허브 업체 삭제 시 예외 발생")
+        void hubManager_cannotDeleteOtherHubCompany() {
+            given(companyRepository.findByIdAndDeletedAtIsNull(COMPANY_ID))
+                    .willReturn(Optional.of(company)); // company.hubId = HUB_A
+
+            assertThatThrownBy(() -> companyService.deleteCompany(COMPANY_ID, REQUESTER_ID, "HUB_MANAGER", HUB_B))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(CompanyErrorCode.COMPANY_HUB_MISMATCH.getCode()));
+        }
+
+        @Test
+        @DisplayName("COMPANY_MANAGER는 삭제 불가 — 예외 발생")
+        void companyManager_cannotDelete() {
+            given(companyRepository.findByIdAndDeletedAtIsNull(COMPANY_ID))
+                    .willReturn(Optional.of(company));
+
+            assertThatThrownBy(() -> companyService.deleteCompany(COMPANY_ID, REQUESTER_ID, "COMPANY_MANAGER", null))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(CompanyErrorCode.COMPANY_ACCESS_DENIED.getCode()));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 업체 삭제 시 예외 발생")
+        void deleteNotFound() {
+            given(companyRepository.findByIdAndDeletedAtIsNull(COMPANY_ID))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> companyService.deleteCompany(COMPANY_ID, REQUESTER_ID, "MASTER", null))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(CompanyErrorCode.COMPANY_NOT_FOUND.getCode()));
+        }
+    }
+
+    // UpdateCompanyCommand 생성 헬퍼 — 반복 코드 제거용
+    private UpdateCompanyCommand updateCommand(String role, UUID requesterHubId, UUID requesterCompanyId) {
+        return UpdateCompanyCommand.builder()
+                .companyId(COMPANY_ID)
+                .requesterId(REQUESTER_ID)
+                .requesterRole(role)
+                .requesterHubId(requesterHubId)
+                .requesterCompanyId(requesterCompanyId)
+                .build();
+    }
+}

--- a/company-service/src/test/java/com/sparta/lucky/company/infrastructure/CompanyJpaRepositoryTest.java
+++ b/company-service/src/test/java/com/sparta/lucky/company/infrastructure/CompanyJpaRepositoryTest.java
@@ -1,0 +1,116 @@
+package com.sparta.lucky.company.infrastructure;
+
+import com.sparta.lucky.company.common.config.AuditConfig;
+import com.sparta.lucky.company.domain.Company;
+import com.sparta.lucky.company.domain.CompanyType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(AuditConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE) // 실제 DB 사용
+class CompanyJpaRepositoryTest {
+
+    // 테스트용 AuditorAware - AuditConfig의 빈을 덮어씀
+    @TestConfiguration
+    @EnableJpaAuditing
+    static class TestAuditConfig {
+        @Bean
+        @Primary
+        public AuditorAware<UUID> auditorAware() {
+            return () -> Optional.of(UUID.fromString("00000000-0000-0000-0000-000000000001"));
+        }
+    }
+
+    @Autowired
+    private CompanyJpaRepository companyJpaRepository;
+
+    private static final UUID HUB_A = UUID.randomUUID();
+    private static final UUID HUB_B = UUID.randomUUID();
+    private static final Pageable PAGE = PageRequest.of(0, 10);
+
+    @BeforeEach
+    void setUp() {
+        // 각 테스트마다 동일한 초기 데이터 4개 삽입
+        companyJpaRepository.saveAll(List.of(
+                Company.builder().name("서울건조식품").companyType(CompanyType.SUPPLIER).hubId(HUB_A).address("주소1").build(),
+                Company.builder().name("부산냉동물류").companyType(CompanyType.RECEIVER).hubId(HUB_A).address("주소2").build(),
+                Company.builder().name("서울전자부품").companyType(CompanyType.SUPPLIER).hubId(HUB_B).address("주소3").build(),
+                Company.builder().name("대구신선식품").companyType(CompanyType.RECEIVER).hubId(HUB_B).address("주소4").build()
+        ));
+    }
+
+    @Test
+    @DisplayName("조건 없으면 전체 조회")
+    void findAll_noCondition() {
+        Page<Company> result = companyJpaRepository.findAllByConditions(null, null, null, PAGE);
+        assertThat(result.getTotalElements()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("name 부분 검색")
+    void findAll_byName() {
+        Page<Company> result = companyJpaRepository.findAllByConditions("서울", null, null, PAGE);
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent()).allMatch(c -> c.getName().contains("서울"));
+    }
+
+    @Test
+    @DisplayName("type 필터")
+    void findAll_byType() {
+        Page<Company> result = companyJpaRepository.findAllByConditions(null, CompanyType.SUPPLIER, null, PAGE);
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent()).allMatch(c -> c.getCompanyType() == CompanyType.SUPPLIER);
+    }
+
+    @Test
+    @DisplayName("hubId 필터")
+    void findAll_byHubId() {
+        Page<Company> result = companyJpaRepository.findAllByConditions(null, null, HUB_A, PAGE);
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent()).allMatch(c -> c.getHubId().equals(HUB_A));
+    }
+
+    @Test
+    @DisplayName("name + type 복합 조건")
+    void findAll_byNameAndType() {
+        Page<Company> result = companyJpaRepository.findAllByConditions("서울", CompanyType.SUPPLIER, null, PAGE);
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent())
+                .allMatch(c -> c.getName().contains("서울") && c.getCompanyType() == CompanyType.SUPPLIER);
+    }
+
+    @Test
+    @DisplayName("Soft Delete된 업체는 조회 제외")
+    void findAll_excludesSoftDeleted() {
+        // given: 업체 하나 soft delete
+        Company toDelete = companyJpaRepository.findAll().get(0);
+        toDelete.softDelete(UUID.randomUUID());
+        companyJpaRepository.save(toDelete);
+
+        // when
+        Page<Company> result = companyJpaRepository.findAllByConditions(null, null, null, PAGE);
+
+        // then: 4개 중 1개 삭제 → 3개만 조회
+        assertThat(result.getTotalElements()).isEqualTo(3);
+    }
+}

--- a/company-service/src/test/resources/application.properties
+++ b/company-service/src/test/resources/application.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:postgresql://localhost:5432/lucky_logistics?currentSchema=company_schema
+spring.datasource.username=lucky
+spring.datasource.password=lucky7777
+spring.jpa.hibernate.ddl-auto=create-drop
+#@SpringBootConfiguration? ????? AuditConfig? ?? ?????? ??
+spring.main.allow-bean-definition-overriding=true

--- a/company-service/src/test/resources/application.properties
+++ b/company-service/src/test/resources/application.properties
@@ -1,6 +1,5 @@
-spring.datasource.url=jdbc:postgresql://localhost:5432/lucky_logistics?currentSchema=company_schema
-spring.datasource.username=lucky
-spring.datasource.password=lucky7777
+spring.datasource.url=${TEST_DB_URL:jdbc:postgresql://localhost:5432/lucky_logistics?currentSchema=company_schema}
+spring.datasource.username=${TEST_DB_USERNAME:lucky}
+spring.datasource.password=${TEST_DB_PASSWORD:lucky7777}
 spring.jpa.hibernate.ddl-auto=create-drop
-#@SpringBootConfiguration? ????? AuditConfig? ?? ?????? ??
 spring.main.allow-bean-definition-overriding=true


### PR DESCRIPTION
## 📋 관련 이슈
- close #27

## 🔧 작업 내용
Company 도메인 (company-service) CRUD API 구현

**구현 범위**
- Domain: Company 엔티티, CompanyType Enum, CompanyErrorCode, CompanyRepository 인터페이스
- Infrastructure: CompanyJpaRepository (@Query 동적 검색), CompanyRepositoryImpl
- Application: CompanyService (역할별 소유권 검증), Command/Result DTO
- Presentation: CompanyController, Request/Response DTO
- Test : CompanyServiceTest, CompanyRepositoryTest

**구현 API**
| Method | URL | 권한 |
|--------|-----|------|
| POST | `/api/v1/companies` | MASTER, HUB_MANAGER |
| GET | `/api/v1/companies` | 전체 |
| GET | `/api/v1/companies/{id}` | 전체 |
| PATCH | `/api/v1/companies/{id}` | MASTER, HUB_MANAGER, COMPANY_MANAGER |
| DELETE | `/api/v1/companies/{id}` | MASTER, HUB_MANAGER |

## ✅ 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [x] 불필요한 주석/코드를 제거했나요?
- [x] 로컬에서 테스트 완료했나요?
- [x] API 명세서와 일치하나요?

## 📝 리뷰 요청 사항
- `CompanyService`의 역할별 소유권 검증 로직 (`validateUpdateAccess`) 방향
- `@Query` 동적 조건 처리 방식 (`IS NULL OR` 패턴)

