### PR TITLE
fix: critical-issues

### DIFF
--- a/company-service/src/main/java/com/sparta/lucky/company/common/entity/BaseEntity.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/common/entity/BaseEntity.java
@@ -23,8 +23,9 @@ public abstract class BaseEntity {
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    // 내부 API/시스템 컨텍스트에서 X-User-Id 헤더 없이 저장 시 NOT NULL 위반 방지
     @CreatedBy
-    @Column(name = "created_by", nullable = false, updatable = false, columnDefinition = "uuid")
+    @Column(name = "created_by", nullable = true, updatable = false, columnDefinition = "uuid")
     private UUID createdBy;
 
     @LastModifiedDate

--- a/company-service/src/main/resources/application.yaml
+++ b/company-service/src/main/resources/application.yaml
@@ -14,12 +14,12 @@ spring:
     hibernate:
       ddl-auto: update
     properties:
-     hibernate:
+      hibernate:
         default_schema: ${COMPANY_SERVICE_SCHEMA:company_schema}
     show-sql: true
   threads:
-   virtual:
-    enabled: true
+    virtual:
+      enabled: true
 
 eureka:
   client:

--- a/product-service/src/main/java/com/sparta/lucky/product/ProductApplication.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/ProductApplication.java
@@ -2,8 +2,11 @@ package com.sparta.lucky.product;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+
 
 @SpringBootApplication
+@EnableFeignClients
 public class ProductApplication {
 
 	public static void main(String[] args) {

--- a/product-service/src/main/java/com/sparta/lucky/product/common/entity/BaseEntity.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/common/entity/BaseEntity.java
@@ -23,8 +23,9 @@ public abstract class BaseEntity {
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    // 내부 API/시스템 컨텍스트에서 X-User-Id 헤더 없이 저장 시 NOT NULL 위반 방지
     @CreatedBy
-    @Column(name = "created_by", nullable = false, updatable = false, columnDefinition = "uuid")
+    @Column(name = "created_by", nullable = true, updatable = false, columnDefinition = "uuid")
     private UUID createdBy;
 
     @LastModifiedDate


### PR DESCRIPTION
## 📋 관련 이슈
> 관련 이슈 번호를 적어주세요.
- close #46

## 🔧 작업 내용
- company-service `application.yaml` YAML 들여쓰기 오류 수정 (`properties.hibernate`, `threads.virtual`
- company-service / product-service `BaseEntity` `created_by` 컬럼 `nullable = false` → `nullable = true` 수정 (내부
  API 및 시스템 컨텍스트에서 X-User-Id 헤더 없이 저장 시 NOT NULL 위반 방지)
- product-service `ProductApplication`에 `@EnableFeignClients` 누락 추가

## ✅ 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [x] 불필요한 주석/코드를 제거했나요?
- [x] 로컬에서 테스트 완료했나요?
- [x] API 명세서와 일치하나요?

## 📝 리뷰 요청 사항
>   - `created_by nullable = true` 변경이 테이블 명세서(NOT NULL)와 달라집니다. 내부 API/시스템 호출 시 Auditor 정보가 없는
  케이스를 허용하기 위한 의도적 변경이므로 검토 바랍니다

## 📷 스크린샷
> API 테스트 결과 등 첨부하면 좋아요.
> (없으면 삭제)




