### PR TITLE
[feat] hub 캐싱 및 route API 1단계(도착 허브 선택)

### DIFF
--- a/hub-service/src/main/java/com/sparta/lucky/hub/HubApplication.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/HubApplication.java
@@ -2,7 +2,9 @@ package com.sparta.lucky.hub;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
+@EnableCaching
 @SpringBootApplication
 public class HubApplication {
 

--- a/hub-service/src/main/java/com/sparta/lucky/hub/application/HubService.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/application/HubService.java
@@ -37,14 +37,14 @@ public class HubService {
     }
 
     @Transactional(readOnly = true)
-    public Page<GetHubResult> getHubs(Pageable pageable) {
+    public Page<GetHubResult> getHubsByPage(Pageable pageable) {
         return hubRepository.findAllByDeletedAtIsNull(pageable)
                 .map(GetHubResult::from);
     }
 
     @Cacheable(cacheNames = "hub")
     @Transactional(readOnly = true)
-    public List<GetHubResult> getAllHubs() {
+    public List<GetHubResult> getHubs() {
         return hubRepository.findAllByDeletedAtIsNull().stream()
                 .map(GetHubResult::from)
                 .toList();

--- a/hub-service/src/main/java/com/sparta/lucky/hub/application/HubService.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/application/HubService.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -59,5 +60,9 @@ public class HubService {
     private Hub findActiveHub(UUID hubId) {
         return hubRepository.findByIdAndDeletedAtIsNull(hubId)
                 .orElseThrow(() -> new BusinessException(HubErrorCode.HUB_NOT_FOUND));
+    }
+
+    public List<Hub> getHubsList() {
+        return hubRepository.findAllByDeletedAtIsNull();
     }
 }

--- a/hub-service/src/main/java/com/sparta/lucky/hub/application/HubService.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/application/HubService.java
@@ -6,6 +6,8 @@ import com.sparta.lucky.hub.common.exception.HubErrorCode;
 import com.sparta.lucky.hub.domain.Hub;
 import com.sparta.lucky.hub.infrastructure.HubRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -20,12 +22,14 @@ public class HubService {
 
     private final HubRepository hubRepository;
 
+    @CacheEvict(cacheNames = "hub", allEntries = true)
     @Transactional
     public CreateHubResult createHub(CreateHubCommand command) {
         Hub hub = Hub.create(command.getName(), command.getAddress(), command.getLatitude(), command.getLongitude());
         return CreateHubResult.from(hubRepository.save(hub));
     }
 
+    @Cacheable(cacheNames = "hub", key = "#hubId")
     @Transactional(readOnly = true)
     public GetHubResult getHub(UUID hubId) {
         Hub hub = findActiveHub(hubId);
@@ -38,6 +42,15 @@ public class HubService {
                 .map(GetHubResult::from);
     }
 
+    @Cacheable(cacheNames = "hub")
+    @Transactional(readOnly = true)
+    public List<GetHubResult> getAllHubs() {
+        return hubRepository.findAllByDeletedAtIsNull().stream()
+                .map(GetHubResult::from)
+                .toList();
+    }
+
+    @CacheEvict(cacheNames = "hub", allEntries = true)
     @Transactional
     public GetHubResult updateHub(UpdateHubCommand command) {
         Hub hub = findActiveHub(command.getHubId());
@@ -45,12 +58,14 @@ public class HubService {
         return GetHubResult.from(hub);
     }
 
+    @CacheEvict(cacheNames = "hub", allEntries = true)
     @Transactional
     public void assignManager(AssignManagerCommand command) {
         Hub hub = findActiveHub(command.getHubId());
         hub.assignManager(command.getManagerId());
     }
 
+    @CacheEvict(cacheNames = "hub", allEntries = true)
     @Transactional
     public void deleteHub(UUID hubId, UUID deletedBy) {
         Hub hub = findActiveHub(hubId);
@@ -60,9 +75,5 @@ public class HubService {
     private Hub findActiveHub(UUID hubId) {
         return hubRepository.findByIdAndDeletedAtIsNull(hubId)
                 .orElseThrow(() -> new BusinessException(HubErrorCode.HUB_NOT_FOUND));
-    }
-
-    public List<Hub> getHubsList() {
-        return hubRepository.findAllByDeletedAtIsNull();
     }
 }

--- a/hub-service/src/main/java/com/sparta/lucky/hub/application/RouteService.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/application/RouteService.java
@@ -23,7 +23,7 @@ public class RouteService {
     public GetRouteResult getRoute(UUID originHubId, BigDecimal destinationLat, BigDecimal destinationLong) {
 
         // 1. destinationLat, destinationLong 기준으로 가장 가까운 destinationHub 찾기
-        List<GetHubResult> hubs = hubService.getAllHubs();
+        List<GetHubResult> hubs = hubService.getHubs();
         UUID destinationHubId = findNearestHub(hubs, destinationLat, destinationLong).getId();
 
         // 2. originHub에서 destinationHub까지 경로 찾기

--- a/hub-service/src/main/java/com/sparta/lucky/hub/application/RouteService.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/application/RouteService.java
@@ -21,10 +21,17 @@ public class RouteService {
 
     @Transactional(readOnly = true)
     public GetRouteResult getRoute(UUID originHubId, BigDecimal destinationLat, BigDecimal destinationLong) {
+        int totalDuration = 0;
+        int totalDistance = 0;
 
         // 1. destinationLat, destinationLong 기준으로 가장 가까운 destinationHub 찾기
         List<GetHubResult> hubs = hubService.getHubs();
         UUID destinationHubId = findNearestHub(hubs, destinationLat, destinationLong).getId();
+
+        // 출발허브 == 도착허브인 경우
+        if (originHubId == destinationHubId) {
+            return GetRouteResult.of(originHubId, destinationHubId, totalDuration, totalDistance, List.of());
+        }
 
         // 2. originHub에서 destinationHub까지 경로 찾기
         // TODO: Dijkstra 구현 예정

--- a/hub-service/src/main/java/com/sparta/lucky/hub/application/RouteService.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/application/RouteService.java
@@ -1,45 +1,58 @@
 package com.sparta.lucky.hub.application;
 
+import com.sparta.lucky.hub.application.dto.GetHubResult;
 import com.sparta.lucky.hub.application.dto.GetRouteResult;
 import com.sparta.lucky.hub.common.exception.BusinessException;
 import com.sparta.lucky.hub.common.exception.HubErrorCode;
-import com.sparta.lucky.hub.domain.Hub;
-import com.sparta.lucky.hub.domain.HubRoute;
-import com.sparta.lucky.hub.infrastructure.HubRepository;
-import com.sparta.lucky.hub.infrastructure.HubRouteRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
-import java.util.*;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class RouteService {
 
     private final HubService hubService;
-    private final HubRouteRepository hubRouteRepository;
 
     @Transactional(readOnly = true)
     public GetRouteResult getRoute(UUID originHubId, BigDecimal destinationLat, BigDecimal destinationLong) {
 
         // 1. destinationLat, destinationLong 기준으로 가장 가까운 destinationHub 찾기
-        List<Hub> hubs = hubService.getHubsList();
-        Hub destinationHub = hubs.get(0);
+        List<GetHubResult> hubs = hubService.getAllHubs();
+        UUID destinationHubId = findNearestHub(hubs, destinationLat, destinationLong).getId();
 
-        // 2. originHub에서 destinationHub까지 경로 찾기 (Dijkstra, duration 기준 최단)
-        // TEST용
-        int totalDuration = 100;
-        int totalDistance = 100;
-        LinkedList<UUID> route = new LinkedList<>();
+        // 2. originHub에서 destinationHub까지 경로 찾기
+        // TODO: Dijkstra 구현 예정
 
-        return GetRouteResult.of(
-                originHubId,
-                destinationHub.getId(),
-                totalDuration,
-                totalDistance,
-                route
+        return GetRouteResult.of(originHubId, destinationHubId, 100, 100, List.of());
+    }
+
+    private GetHubResult findNearestHub(List<GetHubResult> hubs, BigDecimal targetLat, BigDecimal targetLong) {
+        return hubs.stream()
+                .min(Comparator.comparingDouble(hub -> distanceTo(hub, targetLat, targetLong)))
+                .orElseThrow(() -> new BusinessException(HubErrorCode.HUB_NOT_FOUND));
+    }
+
+    private double distanceTo(GetHubResult hub, BigDecimal targetLat, BigDecimal targetLong) {
+        return haversine(
+                hub.getLatitude().doubleValue(), hub.getLongitude().doubleValue(),
+                targetLat.doubleValue(), targetLong.doubleValue()
         );
+    }
+
+    // Haversine 공식으로 두 좌표 간 거리(km) 계산
+    private double haversine(double lat1, double lon1, double lat2, double lon2) {
+        final double R = 6371.0;
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+        return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
     }
 }

--- a/hub-service/src/main/java/com/sparta/lucky/hub/application/RouteService.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/application/RouteService.java
@@ -1,0 +1,45 @@
+package com.sparta.lucky.hub.application;
+
+import com.sparta.lucky.hub.application.dto.GetRouteResult;
+import com.sparta.lucky.hub.common.exception.BusinessException;
+import com.sparta.lucky.hub.common.exception.HubErrorCode;
+import com.sparta.lucky.hub.domain.Hub;
+import com.sparta.lucky.hub.domain.HubRoute;
+import com.sparta.lucky.hub.infrastructure.HubRepository;
+import com.sparta.lucky.hub.infrastructure.HubRouteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class RouteService {
+
+    private final HubService hubService;
+    private final HubRouteRepository hubRouteRepository;
+
+    @Transactional(readOnly = true)
+    public GetRouteResult getRoute(UUID originHubId, BigDecimal destinationLat, BigDecimal destinationLong) {
+
+        // 1. destinationLat, destinationLong 기준으로 가장 가까운 destinationHub 찾기
+        List<Hub> hubs = hubService.getHubsList();
+        Hub destinationHub = hubs.get(0);
+
+        // 2. originHub에서 destinationHub까지 경로 찾기 (Dijkstra, duration 기준 최단)
+        // TEST용
+        int totalDuration = 100;
+        int totalDistance = 100;
+        LinkedList<UUID> route = new LinkedList<>();
+
+        return GetRouteResult.of(
+                originHubId,
+                destinationHub.getId(),
+                totalDuration,
+                totalDistance,
+                route
+        );
+    }
+}

--- a/hub-service/src/main/java/com/sparta/lucky/hub/application/dto/GetHubResult.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/application/dto/GetHubResult.java
@@ -3,12 +3,13 @@ package com.sparta.lucky.hub.application.dto;
 import com.sparta.lucky.hub.domain.Hub;
 import lombok.Getter;
 
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter
-public class GetHubResult {
+public class GetHubResult implements Serializable {
 
     private final UUID id;
     private final UUID managerId;

--- a/hub-service/src/main/java/com/sparta/lucky/hub/application/dto/GetHubResult.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/application/dto/GetHubResult.java
@@ -1,5 +1,7 @@
 package com.sparta.lucky.hub.application.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sparta.lucky.hub.domain.Hub;
 import lombok.Getter;
 
@@ -20,18 +22,37 @@ public class GetHubResult implements Serializable {
     private final LocalDateTime createdAt;
     private final UUID createdBy;
 
-    private GetHubResult(Hub hub) {
-        this.id = hub.getId();
-        this.managerId = hub.getManagerId();
-        this.name = hub.getName();
-        this.address = hub.getAddress();
-        this.latitude = hub.getLatitude();
-        this.longitude = hub.getLongitude();
-        this.createdAt = hub.getCreatedAt();
-        this.createdBy = hub.getCreatedBy();
+    @JsonCreator
+    public GetHubResult(
+            @JsonProperty("id") UUID id,
+            @JsonProperty("managerId") UUID managerId,
+            @JsonProperty("name") String name,
+            @JsonProperty("address") String address,
+            @JsonProperty("latitude") BigDecimal latitude,
+            @JsonProperty("longitude") BigDecimal longitude,
+            @JsonProperty("createdAt") LocalDateTime createdAt,
+            @JsonProperty("createdBy") UUID createdBy
+    ) {
+        this.id = id;
+        this.managerId = managerId;
+        this.name = name;
+        this.address = address;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.createdAt = createdAt;
+        this.createdBy = createdBy;
     }
 
     public static GetHubResult from(Hub hub) {
-        return new GetHubResult(hub);
+        return new GetHubResult(
+                hub.getId(),
+                hub.getManagerId(),
+                hub.getName(),
+                hub.getAddress(),
+                hub.getLatitude(),
+                hub.getLongitude(),
+                hub.getCreatedAt(),
+                hub.getCreatedBy()
+        );
     }
 }

--- a/hub-service/src/main/java/com/sparta/lucky/hub/application/dto/GetRouteQuery.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/application/dto/GetRouteQuery.java
@@ -8,17 +8,17 @@ import java.util.UUID;
 @Getter
 public class GetRouteQuery {
 
-    private final UUID startHubId;
-    private final BigDecimal endLatitude;
-    private final BigDecimal endLongitude;
+    private final UUID originHubId;
+    private final BigDecimal destinationLatitude;
+    private final BigDecimal destinationLongitude;
 
-    private GetRouteQuery(UUID startHubId, BigDecimal endLatitude, BigDecimal endLongitude) {
-        this.startHubId = startHubId;
-        this.endLatitude = endLatitude;
-        this.endLongitude = endLongitude;
+    private GetRouteQuery(UUID originHubId, BigDecimal destinationLatitude, BigDecimal destinationLongitude) {
+        this.originHubId = originHubId;
+        this.destinationLatitude = destinationLatitude;
+        this.destinationLongitude = destinationLongitude;
     }
 
-    public static GetRouteQuery of(UUID startHubId, BigDecimal endLatitude, BigDecimal endLongitude) {
-        return new GetRouteQuery(startHubId, endLatitude, endLongitude);
+    public static GetRouteQuery of(UUID originHubId, BigDecimal destinationLatitude, BigDecimal destinationLongitude) {
+        return new GetRouteQuery(originHubId, destinationLatitude, destinationLongitude);
     }
 }

--- a/hub-service/src/main/java/com/sparta/lucky/hub/application/dto/GetRouteResult.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/application/dto/GetRouteResult.java
@@ -1,6 +1,5 @@
 package com.sparta.lucky.hub.application.dto;
 
-import com.sparta.lucky.hub.domain.HubRoute;
 import lombok.Getter;
 
 import java.util.List;
@@ -9,23 +8,21 @@ import java.util.UUID;
 @Getter
 public class GetRouteResult {
 
-    private final UUID id;
     private final UUID originHubId;
     private final UUID destinationHubId;
-    private final Integer duration;
-    private final Integer distance;
+    private final Integer totalDuration;
+    private final Integer totalDistance;
     private final List<UUID> route;
 
-    private GetRouteResult(HubRoute hubRoute, List<UUID> route) {
-        this.id = hubRoute.getId();
-        this.originHubId = hubRoute.getOriginHubId();
-        this.destinationHubId = hubRoute.getDestinationHubId();
-        this.duration = hubRoute.getDuration();
-        this.distance = hubRoute.getDistance();
+    private GetRouteResult(UUID originHubId, UUID destinationHubId, Integer totalDuration, Integer totalDistance, List<UUID> route) {
+        this.originHubId = originHubId;
+        this.destinationHubId = destinationHubId;
+        this.totalDuration = totalDuration;
+        this.totalDistance = totalDistance;
         this.route = route;
     }
 
-    public static GetRouteResult of(HubRoute hubRoute, List<UUID> route) {
-        return new GetRouteResult(hubRoute, route);
+    public static GetRouteResult of(UUID originHubId, UUID destinationHubId, Integer totalDuration, Integer totalDistance, List<UUID> route) {
+        return new GetRouteResult(originHubId, destinationHubId, totalDuration, totalDistance, route);
     }
 }

--- a/hub-service/src/main/java/com/sparta/lucky/hub/common/config/CacheConfig.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/common/config/CacheConfig.java
@@ -1,0 +1,43 @@
+package com.sparta.lucky.hub.common.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+public class CacheConfig {
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        ObjectMapper objectMapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .activateDefaultTyping(
+                        new ObjectMapper().getPolymorphicTypeValidator(),
+                        ObjectMapper.DefaultTyping.NON_FINAL
+                );
+
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(120))
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
+                )
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(objectMapper))
+                );
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(config)
+                .build();
+    }
+}

--- a/hub-service/src/main/java/com/sparta/lucky/hub/infrastructure/HubRepository.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/infrastructure/HubRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -13,4 +14,6 @@ public interface HubRepository extends JpaRepository<Hub, UUID> {
     Optional<Hub> findByIdAndDeletedAtIsNull(UUID id);
 
     Page<Hub> findAllByDeletedAtIsNull(Pageable pageable);
+
+    List<Hub> findAllByDeletedAtIsNull();
 }

--- a/hub-service/src/main/java/com/sparta/lucky/hub/infrastructure/HubRouteRepository.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/infrastructure/HubRouteRepository.java
@@ -1,0 +1,12 @@
+package com.sparta.lucky.hub.infrastructure;
+
+import com.sparta.lucky.hub.domain.HubRoute;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface HubRouteRepository extends JpaRepository<HubRoute, UUID> {
+
+    List<HubRoute> findAllByDeletedAtIsNull();
+}

--- a/hub-service/src/main/java/com/sparta/lucky/hub/presentation/HubController.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/presentation/HubController.java
@@ -49,7 +49,7 @@ public class HubController {
     @Operation(summary = "허브 목록 조회", description = "허브 목록을 페이지 단위로 조회합니다.")
     @GetMapping
     public ResponseEntity<ApiResponse<Page<GetHubResDto>>> getHubs(@ParameterObject @PageableDefault(size = 10) Pageable pageable) {
-        return ResponseEntity.ok(ApiResponse.success(hubService.getHubs(pageable).map(GetHubResDto::from)));
+        return ResponseEntity.ok(ApiResponse.success(hubService.getHubsByPage(pageable).map(GetHubResDto::from)));
     }
 
     @Operation(summary = "허브 정보 수정", description = "허브의 이름, 주소, 위경도를 수정합니다.")

--- a/hub-service/src/main/java/com/sparta/lucky/hub/presentation/HubInternalController.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/presentation/HubInternalController.java
@@ -38,7 +38,7 @@ public class HubInternalController {
     @Operation(summary = "[Internal] 허브 목록 조회", description = "서비스 내부에서 허브 목록을 페이지 단위로 조회합니다.")
     @GetMapping
     public ResponseEntity<ApiResponse<Page<GetHubResDto>>> getHubs(@ParameterObject @PageableDefault(size = 10) Pageable pageable) {
-        return ResponseEntity.ok(ApiResponse.success(hubService.getHubs(pageable).map(GetHubResDto::from)));
+        return ResponseEntity.ok(ApiResponse.success(hubService.getHubsByPage(pageable).map(GetHubResDto::from)));
     }
 
     @Operation(summary = "[Internal] 허브 매니저 배정", description = "허브에 매니저를 배정합니다.")

--- a/hub-service/src/main/java/com/sparta/lucky/hub/presentation/RouteInternalController.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/presentation/RouteInternalController.java
@@ -3,6 +3,10 @@ package com.sparta.lucky.hub.presentation;
 import com.sparta.lucky.hub.application.RouteService;
 import com.sparta.lucky.hub.application.dto.GetRouteResult;
 import com.sparta.lucky.hub.presentation.dto.GetRouteResDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.math.BigDecimal;
 import java.util.UUID;
 
+@Tag(name = "Route Internal", description = "허브 경로 내부 서비스 간 통신 API")
 @RestController
 @RequestMapping("/internal/api/v1/routes")
 @RequiredArgsConstructor
@@ -19,11 +24,12 @@ public class RouteInternalController {
 
     private final RouteService routeService;
 
+    @Operation(summary = "[Internal] 허브 최단 경로 조회", description = "허브 간 최단 경로를 조회합니다.")
     @GetMapping
     public GetRouteResDto getRoute(
-            @RequestParam UUID originHubId,
-            @RequestParam BigDecimal destinationLat,
-            @RequestParam BigDecimal destinationLong
+            @Parameter(description = "출발 허브 ID") @RequestParam @NotNull UUID originHubId,
+            @Parameter(description = "도착 위도") @RequestParam @NotNull BigDecimal destinationLat,
+            @Parameter(description = "도착 경도") @RequestParam @NotNull BigDecimal destinationLong
     ) {
         GetRouteResult result = routeService.getRoute(originHubId, destinationLat, destinationLong);
 

--- a/hub-service/src/main/java/com/sparta/lucky/hub/presentation/RouteInternalController.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/presentation/RouteInternalController.java
@@ -1,0 +1,32 @@
+package com.sparta.lucky.hub.presentation;
+
+import com.sparta.lucky.hub.application.RouteService;
+import com.sparta.lucky.hub.application.dto.GetRouteResult;
+import com.sparta.lucky.hub.presentation.dto.GetRouteResDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/internal/api/v1/routes")
+@RequiredArgsConstructor
+public class RouteInternalController {
+
+    private final RouteService routeService;
+
+    @GetMapping
+    public GetRouteResDto getRoute(
+            @RequestParam UUID originHubId,
+            @RequestParam BigDecimal destinationLat,
+            @RequestParam BigDecimal destinationLong
+    ) {
+        GetRouteResult result = routeService.getRoute(originHubId, destinationLat, destinationLong);
+
+        return GetRouteResDto.from(result);
+    }
+}

--- a/hub-service/src/main/java/com/sparta/lucky/hub/presentation/dto/GetRouteReqDto.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/presentation/dto/GetRouteReqDto.java
@@ -10,11 +10,11 @@ import java.util.UUID;
 public class GetRouteReqDto {
 
     @NotNull
-    private UUID startHubId;
+    private UUID originHubId;
 
     @NotNull
-    private BigDecimal endLat;
+    private BigDecimal destinationLat;
 
     @NotNull
-    private BigDecimal endLong;
+    private BigDecimal destinationLong;
 }

--- a/hub-service/src/main/java/com/sparta/lucky/hub/presentation/dto/GetRouteResDto.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/presentation/dto/GetRouteResDto.java
@@ -9,19 +9,17 @@ import java.util.UUID;
 @Getter
 public class GetRouteResDto {
 
-    private final UUID id;
     private final UUID originHubId;
     private final UUID destinationHubId;
-    private final Integer duration;
-    private final Integer distance;
+    private final Integer totalDuration;
+    private final Integer totalDistance;
     private final List<UUID> route;
 
     private GetRouteResDto(GetRouteResult result) {
-        this.id = result.getId();
         this.originHubId = result.getOriginHubId();
         this.destinationHubId = result.getDestinationHubId();
-        this.duration = result.getDuration();
-        this.distance = result.getDistance();
+        this.totalDuration = result.getTotalDuration();
+        this.totalDistance = result.getTotalDistance();
         this.route = result.getRoute();
     }
 

--- a/hub-service/src/main/resources/application.yaml
+++ b/hub-service/src/main/resources/application.yaml
@@ -26,6 +26,14 @@ spring:
     default-schema: ${HUB_SERVICE_SCHEMA}
     validate-on-migrate: false
 
+  data:
+    redis:
+      host: ${REDIS_HOST:lucky-redis}
+      port: ${REDIS_PORT:6379}
+
+  cache:
+    type: redis
+
   threads:
     virtual:
       enabled: true


### PR DESCRIPTION
## 📋 관련 이슈
> 관련 이슈 번호를 적어주세요.
- close #

## 🔧 작업 내용

**1. 기존 table 필드명 변경**

delivery의 필드명과 통일하여 origin, destination으로 수정
p_hub_route 테이블) startHubId -> origin_hub_id / endHubId -> destination_hub_id

**2. Hub 목록 Redis 캐싱**
- `CacheConfig` 추가 - `JavaTimeModule` 등록, TTL 120분, JSON 직렬화 설정
- `getAllHubs()` - `hub::SimpleKey []` 키로 전체 허브 목록 캐싱
- `getHub(id)` - `hub::{uuid}` 키로 개별 허브 캐싱
- 허브 생성/수정/삭제/담당자 변경 시 `hub` 캐시 전체 evict

> `hub::SimpleKey []`(전체 목록)와 `hub::{uuid}`(개별)는 좀더 공부해보고 수정될 수 있습니다.

**3. 경로 조회 1단계 구현**
- `RouteService.getRoute()` - Haversine 공식으로 목적지 좌표와 가장 가까운
허브 탐색

## ✅ 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [x] 불필요한 주석/코드를 제거했나요?
- [x] 로컬에서 테스트 완료했나요?
- [x] API 명세서와 일치하나요?

## 📷 스크린샷

**_`GET /internal/api/v1/hubs/routes` 는 현재 테스트용으로 임시데이트를 return하도록 만들어두었습니다._**

<img width="891" height="550" alt="스크린샷 2026-04-01 15 50 27" src="https://github.com/user-attachments/assets/7557c010-5c0c-41d3-9a17-35c163c6c4a4" />


