### PR TITLE
feat :: driver create & delete

### DIFF
--- a/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/application/DeliveryDriverService.java
+++ b/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/application/DeliveryDriverService.java
@@ -6,7 +6,6 @@ import com.sparta.lucky.deliveryservice.common.error.exceptions.NotFoundExceptio
 import com.sparta.lucky.deliveryservice.common.response.ResponseCode;
 import com.sparta.lucky.deliveryservice.domain.driver.DeliveryDriver;
 import com.sparta.lucky.deliveryservice.domain.repos.DeliveryDriverRepository;
-import com.sparta.lucky.deliveryservice.infrastructure.JpaDeliveryDriverRepository;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,7 +24,7 @@ public class DeliveryDriverService {
      * 존재하지 않는 User 또는 Hub의 ID로 시도하거나, 이미 존재하는 배송 담당자가 있는 경우 추가되지 않습니다.
      * @param command 생성할 배송 담당자의 정보를 담은 dto
      */
-    // TODO : add Transactional
+    @Transactional
     public void createDriver(DeliveryDriverCreateCommand command) {
         // TODO : add validation logic
         // Check if the User and Hub exist.

--- a/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/application/DeliveryDriverService.java
+++ b/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/application/DeliveryDriverService.java
@@ -31,7 +31,7 @@ public class DeliveryDriverService {
         // if not exist, throw bad request exception.
 
         // if user already exists as delivery driver, throw conflict exception.
-        if(deliveryDriverRepository.findActiveById(command.driverId()).isPresent()) {
+        if(deliveryDriverRepository.findActiveByUserId(command.driverId()).isPresent()) {
             throw new ConflictException(ResponseCode.DRIVER_EXISTS);
         }
 
@@ -46,7 +46,7 @@ public class DeliveryDriverService {
      */
     @Transactional
     public void deleteDriver(UUID driverId, UUID accessId) {
-        DeliveryDriver deliveryDriver = deliveryDriverRepository.findActiveById(driverId)
+        DeliveryDriver deliveryDriver = deliveryDriverRepository.findActiveByUserId(driverId)
             .orElseThrow(() -> new NotFoundException(ResponseCode.DRIVER_NOT_FOUND));
         deliveryDriver.softDelete(accessId);
     }

--- a/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/application/DeliveryDriverService.java
+++ b/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/application/DeliveryDriverService.java
@@ -2,13 +2,16 @@ package com.sparta.lucky.deliveryservice.application;
 
 import com.sparta.lucky.deliveryservice.application.dto.DeliveryDriverCreateCommand;
 import com.sparta.lucky.deliveryservice.common.error.exceptions.ConflictException;
+import com.sparta.lucky.deliveryservice.common.error.exceptions.NotFoundException;
 import com.sparta.lucky.deliveryservice.common.response.ResponseCode;
 import com.sparta.lucky.deliveryservice.domain.driver.DeliveryDriver;
 import com.sparta.lucky.deliveryservice.domain.repos.DeliveryDriverRepository;
 import com.sparta.lucky.deliveryservice.infrastructure.JpaDeliveryDriverRepository;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -22,6 +25,7 @@ public class DeliveryDriverService {
      * 존재하지 않는 User 또는 Hub의 ID로 시도하거나, 이미 존재하는 배송 담당자가 있는 경우 추가되지 않습니다.
      * @param command 생성할 배송 담당자의 정보를 담은 dto
      */
+    // TODO : add Transactional
     public void createDriver(DeliveryDriverCreateCommand command) {
         // TODO : add validation logic
         // Check if the User and Hub exist.
@@ -34,5 +38,17 @@ public class DeliveryDriverService {
 
         // save new delivery driver.
         deliveryDriverRepository.save(DeliveryDriver.create(command));
+    }
+
+    /**
+     * 배송 담당자 데이터를 삭제합니다.
+     * @param driverId 삭제하려는 배송 담당자의 ID
+     * @param accessId 삭제처리를 시도한 사용자의 ID
+     */
+    @Transactional
+    public void deleteDriver(UUID driverId, UUID accessId) {
+        DeliveryDriver deliveryDriver = deliveryDriverRepository.findActiveById(driverId)
+            .orElseThrow(() -> new NotFoundException(ResponseCode.DRIVER_NOT_FOUND));
+        deliveryDriver.softDelete(accessId);
     }
 }

--- a/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/application/DeliveryDriverService.java
+++ b/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/application/DeliveryDriverService.java
@@ -1,0 +1,38 @@
+package com.sparta.lucky.deliveryservice.application;
+
+import com.sparta.lucky.deliveryservice.application.dto.DeliveryDriverCreateCommand;
+import com.sparta.lucky.deliveryservice.common.error.exceptions.ConflictException;
+import com.sparta.lucky.deliveryservice.common.response.ResponseCode;
+import com.sparta.lucky.deliveryservice.domain.driver.DeliveryDriver;
+import com.sparta.lucky.deliveryservice.domain.repos.DeliveryDriverRepository;
+import com.sparta.lucky.deliveryservice.infrastructure.JpaDeliveryDriverRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DeliveryDriverService {
+
+    private final DeliveryDriverRepository deliveryDriverRepository;
+
+    /**
+     * 배송 담당자를 DB에 추가합니다.<br>
+     * 존재하지 않는 User 또는 Hub의 ID로 시도하거나, 이미 존재하는 배송 담당자가 있는 경우 추가되지 않습니다.
+     * @param command 생성할 배송 담당자의 정보를 담은 dto
+     */
+    public void createDriver(DeliveryDriverCreateCommand command) {
+        // TODO : add validation logic
+        // Check if the User and Hub exist.
+        // if not exist, throw bad request exception.
+
+        // if user already exists as delivery driver, throw conflict exception.
+        if(deliveryDriverRepository.findActiveById(command.driverId()).isPresent()) {
+            throw new ConflictException(ResponseCode.DRIVER_EXISTS);
+        }
+
+        // save new delivery driver.
+        deliveryDriverRepository.save(DeliveryDriver.create(command));
+    }
+}

--- a/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/application/dto/DeliveryDriverCreateCommand.java
+++ b/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/application/dto/DeliveryDriverCreateCommand.java
@@ -1,0 +1,12 @@
+package com.sparta.lucky.deliveryservice.application.dto;
+
+import com.sparta.lucky.deliveryservice.domain.driver.code.DriverType;
+import java.util.UUID;
+
+public record DeliveryDriverCreateCommand(
+    UUID driverId,
+    UUID hubId,
+    DriverType type
+) {
+
+}

--- a/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/common/entity/BaseEntity.java
+++ b/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/common/entity/BaseEntity.java
@@ -19,25 +19,25 @@ public abstract class BaseEntity {
 
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+    protected LocalDateTime createdAt;
 
     @CreatedBy
     @Column(name = "created_by", nullable = false, updatable = false, columnDefinition = "uuid")
-    private UUID createdBy;
+    protected UUID createdBy;
 
     @LastModifiedDate
     @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
+    protected LocalDateTime updatedAt;
 
     @LastModifiedBy
     @Column(name = "updated_by", columnDefinition = "uuid")
-    private UUID updatedBy;
+    protected UUID updatedBy;
 
     @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
+    protected LocalDateTime deletedAt;
 
     @Column(name = "deleted_by", columnDefinition = "uuid")
-    private UUID deletedBy;
+    protected UUID deletedBy;
 
     // 삭제 여부 확인
     public boolean isDeleted() {

--- a/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/common/response/ResponseCode.java
+++ b/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/common/response/ResponseCode.java
@@ -17,6 +17,7 @@ public enum ResponseCode {
     // DRIVER(3)
     DRIVER_CREATED("DELIVERY_300", HttpStatus.CREATED, "Driver Created"),
     DRIVER_EXISTS("DELIVERY_301", HttpStatus.CONFLICT, "Driver already exists"),
+    DRIVER_NOT_FOUND("DELIVERY_302", HttpStatus.NOT_FOUND, "Driver not found"),
     ;
 
     private final String code;

--- a/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/domain/driver/DeliveryDriver.java
+++ b/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/domain/driver/DeliveryDriver.java
@@ -58,8 +58,12 @@ public class DeliveryDriver extends BaseEntity {
         return driver;
     }
 
-    public void softDelete(UUID id) {
+    /**
+     * 배송 담당자 데이터를 soft delete합니다.
+     * @param accessId 요청한 사용자의 ID
+     */
+    public void softDelete(UUID accessId) {
         this.deletedAt = LocalDateTime.now();
-        this.deletedBy = id;
+        this.deletedBy = accessId;
     }
 }

--- a/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/domain/driver/DeliveryDriver.java
+++ b/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/domain/driver/DeliveryDriver.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
@@ -15,6 +16,7 @@ import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
 
 @Entity
 @Getter
@@ -23,8 +25,13 @@ import lombok.NoArgsConstructor;
 public class DeliveryDriver extends BaseEntity {
 
     @Id
+    @GeneratedValue
+    @UuidGenerator
     @Column(name="id", updatable = false, nullable = false)
     private UUID id;
+
+    @Column(name="user_id", updatable = false, nullable = false)
+    private UUID userId;
 
     @Column(name="hub_id", nullable = false)
     private UUID hubId;
@@ -51,7 +58,7 @@ public class DeliveryDriver extends BaseEntity {
      */
     public static DeliveryDriver create(DeliveryDriverCreateCommand command) {
         DeliveryDriver driver = new DeliveryDriver();
-        driver.id = command.driverId();
+        driver.userId = command.driverId();
         driver.hubId = command.hubId();
         driver.type = command.type();
         driver.status = DriverStatus.IDLE;

--- a/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/domain/driver/DeliveryDriver.java
+++ b/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/domain/driver/DeliveryDriver.java
@@ -1,29 +1,27 @@
 package com.sparta.lucky.deliveryservice.domain.driver;
 
+import com.sparta.lucky.deliveryservice.application.dto.DeliveryDriverCreateCommand;
+import com.sparta.lucky.deliveryservice.common.entity.BaseEntity;
 import com.sparta.lucky.deliveryservice.domain.driver.code.DriverStatus;
 import com.sparta.lucky.deliveryservice.domain.driver.code.DriverType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.UuidGenerator;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "p_delivery_driver", schema = "delivery_schema")
-public class DeliveryDriver {
+public class DeliveryDriver extends BaseEntity {
 
     @Id
-    @GeneratedValue
-    @UuidGenerator
     @Column(name="id", updatable = false, nullable = false)
     private UUID id;
 
@@ -40,4 +38,22 @@ public class DeliveryDriver {
     @Enumerated(EnumType.STRING)
     @Column(name="status", nullable = false)
     private DriverStatus status;
+
+
+    // Factory Methods ====================================================
+
+    /**
+     * 배송 담당자 객체를 생성합니다.<br>
+     * 새로 생성되는 배송 담당자의 status는 {@code IDLE}입니다.
+     * @param command 생성할 배송 담당자의 정보를 담은 dto
+     * @return {@link DeliveryDriver}
+     */
+    public static DeliveryDriver create(DeliveryDriverCreateCommand command) {
+        DeliveryDriver driver = new DeliveryDriver();
+        driver.id = command.driverId();
+        driver.hubId = command.hubId();
+        driver.type = command.type();
+        driver.status = DriverStatus.IDLE;
+        return driver;
+    }
 }

--- a/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/domain/driver/DeliveryDriver.java
+++ b/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/domain/driver/DeliveryDriver.java
@@ -10,6 +10,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -55,5 +56,10 @@ public class DeliveryDriver extends BaseEntity {
         driver.type = command.type();
         driver.status = DriverStatus.IDLE;
         return driver;
+    }
+
+    public void softDelete(UUID id) {
+        this.deletedAt = LocalDateTime.now();
+        this.deletedBy = id;
     }
 }

--- a/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/domain/repos/DeliveryDriverRepository.java
+++ b/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/domain/repos/DeliveryDriverRepository.java
@@ -6,6 +6,6 @@ import java.util.UUID;
 
 public interface DeliveryDriverRepository {
 
-    Optional<DeliveryDriver> findActiveById(UUID id);
+    Optional<DeliveryDriver> findActiveByUserId(UUID id);
     DeliveryDriver save(DeliveryDriver deliveryDriver);
 }

--- a/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/domain/repos/DeliveryDriverRepository.java
+++ b/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/domain/repos/DeliveryDriverRepository.java
@@ -1,0 +1,11 @@
+package com.sparta.lucky.deliveryservice.domain.repos;
+
+import com.sparta.lucky.deliveryservice.domain.driver.DeliveryDriver;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface DeliveryDriverRepository {
+
+    Optional<DeliveryDriver> findActiveById(UUID id);
+    DeliveryDriver save(DeliveryDriver deliveryDriver);
+}

--- a/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/infrastructure/JpaDeliveryDriverRepository.java
+++ b/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/infrastructure/JpaDeliveryDriverRepository.java
@@ -1,0 +1,22 @@
+package com.sparta.lucky.deliveryservice.infrastructure;
+
+import com.sparta.lucky.deliveryservice.domain.driver.DeliveryDriver;
+import com.sparta.lucky.deliveryservice.domain.repos.DeliveryDriverRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JpaDeliveryDriverRepository
+    extends JpaRepository<DeliveryDriver, UUID>, DeliveryDriverRepository {
+
+    Optional<DeliveryDriver> findByIdAndDeletedAtIsNull(UUID id);
+
+
+    // override ====================================================
+    @Override
+    default Optional<DeliveryDriver> findActiveById(UUID id) {
+        return findByIdAndDeletedAtIsNull(id);
+    }
+}

--- a/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/infrastructure/JpaDeliveryDriverRepository.java
+++ b/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/infrastructure/JpaDeliveryDriverRepository.java
@@ -11,12 +11,12 @@ import org.springframework.stereotype.Repository;
 public interface JpaDeliveryDriverRepository
     extends JpaRepository<DeliveryDriver, UUID>, DeliveryDriverRepository {
 
-    Optional<DeliveryDriver> findByIdAndDeletedAtIsNull(UUID id);
+    Optional<DeliveryDriver> findByUserIdAndDeletedAtIsNull(UUID id);
 
 
     // override ====================================================
     @Override
-    default Optional<DeliveryDriver> findActiveById(UUID id) {
-        return findByIdAndDeletedAtIsNull(id);
+    default Optional<DeliveryDriver> findActiveByUserId(UUID id) {
+        return findByUserIdAndDeletedAtIsNull(id);
     }
 }

--- a/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/presentation/driver/DeliveryDriverController.java
+++ b/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/presentation/driver/DeliveryDriverController.java
@@ -27,6 +27,7 @@ public class DeliveryDriverController {
     // TODO : Need to add method to implement the logic below.
     // If user's role is HUB_MANAGER, check request.hubId and user.hubId
     // If request.hubId is different from `user.hubId`, throw forbidden exception
+    // To ensure authorization, add logic that throws an exception if the user's role is not MASTER or HUB_MANAGER
 
     @Operation(summary = "배송 담당자 생성", description = "새로운 배송 담당자를 생성합니다.")
     @PostMapping

--- a/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/presentation/driver/DeliveryDriverController.java
+++ b/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/presentation/driver/DeliveryDriverController.java
@@ -1,0 +1,38 @@
+package com.sparta.lucky.deliveryservice.presentation.driver;
+
+import com.sparta.lucky.deliveryservice.application.DeliveryDriverService;
+import com.sparta.lucky.deliveryservice.common.response.CommonApiResponse;
+import com.sparta.lucky.deliveryservice.common.response.ResponseCode;
+import com.sparta.lucky.deliveryservice.presentation.driver.payload.DeliveryDriverCreateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+// TODO: Add Authorization
+@RestController
+@RequestMapping("/api/v1/drivers")
+@RequiredArgsConstructor
+public class DeliveryDriverController {
+
+    private final DeliveryDriverService deliveryDriverService;
+
+    @Operation(summary = "배송 담당자 생성", description = "새로운 배송 담당자를 생성합니다.\n허브 담당자의 경우 request param으로 hub_id가 필요합니다.")
+    @PostMapping
+    public CommonApiResponse<Void> createDriver(
+        @RequestBody @Valid final DeliveryDriverCreateRequest request
+    ) {
+        // TODO : Need to add code to implement the logic below.
+        // If user's role is HUB_MANAGER, check request.hubId and user.hubId
+        // If request.hubId is different from `user.hubId`, throw forbidden exception
+
+        deliveryDriverService.createDriver(request.toCommand());
+
+        return CommonApiResponse.success(ResponseCode.DRIVER_CREATED);
+    }
+}

--- a/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/presentation/driver/DeliveryDriverController.java
+++ b/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/presentation/driver/DeliveryDriverController.java
@@ -33,6 +33,8 @@ public class DeliveryDriverController {
     public CommonApiResponse<Void> createDriver(
         @RequestBody @Valid final DeliveryDriverCreateRequest request
     ) {
+        // TODO : Need to add role validation and processing method here
+
         deliveryDriverService.createDriver(request.toCommand());
 
         return CommonApiResponse.success(ResponseCode.DRIVER_CREATED);
@@ -43,6 +45,8 @@ public class DeliveryDriverController {
     public CommonApiResponse<LocalDateTime> deleteDriver(
         @PathVariable UUID driverId
     ) {
+        // TODO : Need to add role validation and processing method here
+
         // Authentication logic has not yet been added, random UUID is used
         deliveryDriverService.deleteDriver(driverId, UUID.randomUUID());
 

--- a/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/presentation/driver/DeliveryDriverController.java
+++ b/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/presentation/driver/DeliveryDriverController.java
@@ -24,15 +24,15 @@ public class DeliveryDriverController {
 
     private final DeliveryDriverService deliveryDriverService;
 
+    // TODO : Need to add method to implement the logic below.
+    // If user's role is HUB_MANAGER, check request.hubId and user.hubId
+    // If request.hubId is different from `user.hubId`, throw forbidden exception
+
     @Operation(summary = "배송 담당자 생성", description = "새로운 배송 담당자를 생성합니다.")
     @PostMapping
     public CommonApiResponse<Void> createDriver(
         @RequestBody @Valid final DeliveryDriverCreateRequest request
     ) {
-        // TODO : Need to add code to implement the logic below.
-        // If user's role is HUB_MANAGER, check request.hubId and user.hubId
-        // If request.hubId is different from `user.hubId`, throw forbidden exception
-
         deliveryDriverService.createDriver(request.toCommand());
 
         return CommonApiResponse.success(ResponseCode.DRIVER_CREATED);
@@ -43,10 +43,6 @@ public class DeliveryDriverController {
     public CommonApiResponse<LocalDateTime> deleteDriver(
         @PathVariable UUID driverId
     ) {
-        // TODO : Need to add code to implement the logic below.
-        // If user's role is HUB_MANAGER, check request.hubId and user.hubId
-        // If request.hubId is different from `user.hubId`, throw forbidden exception
-
         // Authentication logic has not yet been added, random UUID is used
         deliveryDriverService.deleteDriver(driverId, UUID.randomUUID());
 

--- a/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/presentation/driver/DeliveryDriverController.java
+++ b/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/presentation/driver/DeliveryDriverController.java
@@ -48,6 +48,7 @@ public class DeliveryDriverController {
     ) {
         // TODO : Need to add role validation and processing method here
 
+        // TODO : Replace UUID.randomUUID() to accessId
         // Authentication logic has not yet been added, random UUID is used
         deliveryDriverService.deleteDriver(driverId, UUID.randomUUID());
 

--- a/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/presentation/driver/DeliveryDriverController.java
+++ b/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/presentation/driver/DeliveryDriverController.java
@@ -6,9 +6,11 @@ import com.sparta.lucky.deliveryservice.common.response.ResponseCode;
 import com.sparta.lucky.deliveryservice.presentation.driver.payload.DeliveryDriverCreateRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
-import java.util.Map;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,5 +36,20 @@ public class DeliveryDriverController {
         deliveryDriverService.createDriver(request.toCommand());
 
         return CommonApiResponse.success(ResponseCode.DRIVER_CREATED);
+    }
+
+    @Operation(summary = "배송 담당자 삭제", description = "배송 담당자 데이터를 삭제합니다.")
+    @DeleteMapping("/{driverId}")
+    public CommonApiResponse<LocalDateTime> deleteDriver(
+        @PathVariable UUID driverId
+    ) {
+        // TODO : Need to add code to implement the logic below.
+        // If user's role is HUB_MANAGER, check request.hubId and user.hubId
+        // If request.hubId is different from `user.hubId`, throw forbidden exception
+
+        // Authentication logic has not yet been added, random UUID is used
+        deliveryDriverService.deleteDriver(driverId, UUID.randomUUID());
+
+        return CommonApiResponse.success(ResponseCode.OK, LocalDateTime.now());
     }
 }

--- a/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/presentation/driver/DeliveryDriverController.java
+++ b/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/presentation/driver/DeliveryDriverController.java
@@ -22,7 +22,7 @@ public class DeliveryDriverController {
 
     private final DeliveryDriverService deliveryDriverService;
 
-    @Operation(summary = "배송 담당자 생성", description = "새로운 배송 담당자를 생성합니다.\n허브 담당자의 경우 request param으로 hub_id가 필요합니다.")
+    @Operation(summary = "배송 담당자 생성", description = "새로운 배송 담당자를 생성합니다.")
     @PostMapping
     public CommonApiResponse<Void> createDriver(
         @RequestBody @Valid final DeliveryDriverCreateRequest request

--- a/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/presentation/driver/payload/DeliveryDriverCreateRequest.java
+++ b/delivery-service/src/main/java/com/sparta/lucky/deliveryservice/presentation/driver/payload/DeliveryDriverCreateRequest.java
@@ -1,0 +1,22 @@
+package com.sparta.lucky.deliveryservice.presentation.driver.payload;
+
+import com.sparta.lucky.deliveryservice.application.dto.DeliveryDriverCreateCommand;
+import com.sparta.lucky.deliveryservice.domain.driver.code.DriverType;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record DeliveryDriverCreateRequest(
+
+    @NotNull
+    UUID driverId,
+
+    @NotNull
+    UUID hubId,
+
+    @NotNull
+    DriverType type
+) {
+    public DeliveryDriverCreateCommand toCommand() {
+        return new DeliveryDriverCreateCommand(driverId, hubId, type);
+    }
+}

--- a/delivery-service/src/main/resources/db/migration/V0.1.0__add_driver_id_field.sql
+++ b/delivery-service/src/main/resources/db/migration/V0.1.0__add_driver_id_field.sql
@@ -1,0 +1,12 @@
+-- 기존에 user_id를 p_delivery_driver의 PK로 사용하던 방식에서,
+-- id는 식별자로 두고, user_id를 별도로 두는 방식으로 변경
+ALTER TABLE delivery_schema.p_delivery_driver
+ADD COLUMN user_id UUID;
+
+-- 기존 데이터가 있다면 id 값을 user_id로 복사
+UPDATE delivery_schema.p_delivery_driver
+SET user_id = id;
+
+-- NOT NULL 제약 추가
+ALTER TABLE delivery_schema.p_delivery_driver
+ALTER COLUMN user_id SET NOT NULL;

--- a/delivery-service/src/main/resources/db/migration/V0.1.1__add_missing_fields.sql
+++ b/delivery-service/src/main/resources/db/migration/V0.1.1__add_missing_fields.sql
@@ -1,0 +1,61 @@
+-- delivery driver
+ALTER TABLE delivery_schema.p_delivery_driver
+ADD COLUMN created_at TIMESTAMP,
+ADD COLUMN created_by UUID,
+ADD COLUMN updated_at TIMESTAMP,
+ADD COLUMN updated_by UUID,
+ADD COLUMN deleted_at TIMESTAMP,
+ADD COLUMN deleted_by UUID;
+
+UPDATE delivery_schema.p_delivery_driver
+SET
+created_at = now(),
+created_by = '00000000-0000-0000-0000-000000000000',
+updated_at = now(),
+updated_by = '00000000-0000-0000-0000-000000000000';
+
+ALTER TABLE delivery_schema.p_delivery_driver
+ALTER COLUMN created_at SET NOT NULL,
+ALTER COLUMN created_by SET NOT NULL;
+
+-- delivery
+ALTER TABLE delivery_schema.p_delivery
+ADD COLUMN created_at TIMESTAMP,
+ADD COLUMN created_by UUID,
+ADD COLUMN updated_at TIMESTAMP,
+ADD COLUMN updated_by UUID,
+ADD COLUMN deleted_at TIMESTAMP,
+ADD COLUMN deleted_by UUID;
+
+UPDATE delivery_schema.p_delivery
+SET
+created_at = now(),
+created_by = '00000000-0000-0000-0000-000000000000',
+updated_at = now(),
+updated_by = '00000000-0000-0000-0000-000000000000';
+
+ALTER TABLE delivery_schema.p_delivery
+ALTER COLUMN created_at SET NOT NULL,
+ALTER COLUMN created_by SET NOT NULL;
+
+-- delivery route
+ALTER TABLE delivery_schema.p_delivery_route
+ADD COLUMN created_at TIMESTAMP,
+ADD COLUMN created_by UUID,
+ADD COLUMN updated_at TIMESTAMP,
+ADD COLUMN updated_by UUID,
+ADD COLUMN deleted_at TIMESTAMP,
+ADD COLUMN deleted_by UUID;
+
+UPDATE delivery_schema.p_delivery_route
+SET
+created_at = now(),
+created_by = '00000000-0000-0000-0000-000000000000',
+updated_at = now(),
+updated_by = '00000000-0000-0000-0000-000000000000';
+
+ALTER TABLE delivery_schema.p_delivery_route
+ALTER COLUMN created_at SET NOT NULL,
+ALTER COLUMN created_by SET NOT NULL;
+
+


### PR DESCRIPTION
## 📋 관련 이슈
> 관련 이슈 번호를 적어주세요.
- #9

## 🔧 작업 내용
> 어떤 작업을 했는지 설명해주세요.

## ✅ 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [x] 불필요한 주석/코드를 제거했나요?
- [ ] 로컬에서 테스트 완료했나요?
- [x] API 명세서와 일치하나요?

## 📝 리뷰 요청 사항
> 리뷰어가 집중해서 봐줬으면 하는 부분을 적어주세요.
 
- delete코드가 많지 않고, create기능을 구현하는 중에 이미 일부 코드가 PR중에 있었기에 delete브랜치에 합쳐서 PR올립니다.

### 왜 레포지토리를 구분해서 작성했을까요?
- 저희 팀의 컨벤션에서 repo와 jpa구현체를 나누는 것으로 되어있습니다.
- 따라서, 기능정의를 위한 순수 repo를 domain에 두고, 실제 JPA구현은 infrastructure에서 다중상속 방식으로 구현했습니다.
- 일반적으로 자주 사용되는 방식은 하나의 repo에서 `JpaRepository`를 바로 상속받는 단일상속 방식이라고 하지만, 설계의 의도나 DDD를 더 엄격하게 지키려는 경우 다중상속 또는 어댑터 방식을 사용하기도 한다고는 합니다.
- 하지만 어댑터 방식을 사용하는 경우, 기술교체에 유리하다는 장점이 있지만, 관리포인트가 너무 늘어날 수 있다는 단점이 생길 수 있습니다.
- 그래서 저는 단일상속보다는 계층적 의미를 명확히 할 수 있으면서도, 어댑터 방식보다는 가벼운 다중상속 방식을 통해 컨벤션을 지키려 해보았습니다.
- 추가로, 단일 상속 방식을 사용하는 경우 domain/repo같은 경로에 두는게 맞다고 합니다.

### 테스트
- CRUD전부 작성 후 테스트 하기위해 테스트는 따로 진행하지 않았습니다.

### 비어있는 로직
- 현재 작성하지 않은 로직은 주석으로 처리해두었는데, 기본적인 기능 개발-> 테스트 후 작성하려고 합니다.
- 대충 전부 구현되면 이런 로직으로 구현되겠구나 하고 넘어가주시면 될 것 같습니다.


## 📷 스크린샷
> API 테스트 결과 등 첨부하면 좋아요.
> (없으면 삭제)




