### PR TITLE
Feat/product/crud

### DIFF
--- a/product-service/src/main/java/com/sparta/lucky/product/ProductApplication.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/ProductApplication.java
@@ -2,8 +2,10 @@ package com.sparta.lucky.product;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class ProductApplication {
 
 	public static void main(String[] args) {

--- a/product-service/src/main/java/com/sparta/lucky/product/application/ProductService.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/application/ProductService.java
@@ -1,0 +1,336 @@
+package com.sparta.lucky.product.application;
+
+import com.sparta.lucky.product.application.dto.*;
+import com.sparta.lucky.product.common.exception.BusinessException;
+import com.sparta.lucky.product.domain.*;
+import com.sparta.lucky.product.infrastructure.feign.CompanyClient;
+import com.sparta.lucky.product.infrastructure.feign.HubClient;
+import com.sparta.lucky.product.infrastructure.feign.dto.CompanyResponse;
+import com.sparta.lucky.product.infrastructure.feign.dto.HubResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProductService {
+
+    // 매직스트링 상수화
+    private static final String ROLE_MASTER = "MASTER";
+    private static final String ROLE_HUB_MANAGER = "HUB_MANAGER";
+    private static final String ROLE_COMPANY_MANAGER = "COMPANY_MANAGER";
+
+    // 내부 요청 헤더값 상수화
+    private static final String INTERNAL_REQUEST = "true";
+
+    private final ProductRepository productRepository;
+    private final ProductStockRepository productStockRepository;
+    private final CompanyClient companyClient;
+    private final HubClient hubClient;
+
+    @Transactional
+    public CreateProductResult createProduct(CreateProductCommand command) {
+        log.info("상품 생성 요청 - requester: {}, role: {}, companyId: {}, hubId: {}, name: {}, price: {}, stock: {}",
+                command.getRequesterId(), command.getRequesterRole(), command.getCompanyId(), command.getHubId()
+        , command.getName(), command.getPrice(), command.getStock());
+
+        // 업체 실존 검증 - company-service 내부 API 호출
+        CompanyInfo company = validateCompany(command.getCompanyId());
+
+        // 허브 실존 검증 - hub-service 내부 API 호출
+        validateHub(command.getHubId());
+
+        // 권한 검증 (내부 메서드)
+        validateAuthority(
+                command.getRequesterId(),
+                command.getRequesterRole(),
+                command.getRequesterHubId(),
+                command.getHubId(),
+                company);
+
+        // Product와 ProductStock을 나누어 작성 및 저장
+        Product product = Product.builder()
+                .companyId(command.getCompanyId())
+                .hubId(command.getHubId())
+                .name(command.getName())
+                .price(command.getPrice())
+                .status(ProductStatus.ACTIVE)
+                .build();
+        productRepository.save(product);
+
+        // Product 저장 후 생성된 Id를 바탕으로 ProductStock 생성 및 저장
+        // 같은 트랜잭션 - product 저장 실패시 함께 롤백
+        ProductStock stock = ProductStock.builder()
+                .product(product)
+                .hubId(product.getHubId())
+                .stock(command.getStock())
+                .version(0L)
+                .build();
+        productStockRepository.save(stock);
+
+        //응답에 Product 정보, stock 정보를 함께 담아서 반환
+        return CreateProductResult.from(product, stock);
+    }
+
+    public Page<GetProductResult> getProducts(
+            String name, ProductStatus status, UUID companyId,
+            String requesterRole, UUID requesterHubId,
+            Pageable pageable) {
+
+        // HUB_MANAGER는 담당 허브 소속 상품만 조회 가능 — 자동으로 hubId 필터 적용
+        UUID hubFilter = ROLE_HUB_MANAGER.equals(requesterRole) ? requesterHubId : null;
+
+        return productRepository
+                .findAllWithStock(name, status, companyId, hubFilter, pageable)
+                .map(GetProductResult::from);
+    }
+
+    public GetProductResult getProduct(UUID productId, String requesterRole, UUID requesterHubId) {
+
+        Product product = productRepository.findByIdWithStock(productId)
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        // HUB_MANAGER는 담당 허브 소속 상품만 조회 가능
+        if (ROLE_HUB_MANAGER.equals(requesterRole) &&
+                !product.getHubId().equals(requesterHubId)) {
+            throw new BusinessException(ProductErrorCode.PRODUCT_NOT_ALLOWED);
+        }
+
+        return GetProductResult.from(product);
+    }
+
+    @Transactional
+    public GetProductResult updateProduct(UpdateProductCommand command) {
+        log.info("상품 수정 요청 - companyId: {}, requester: {}, role: {}",
+                command.getCompanyId(), command.getRequesterId(), command.getRequesterRole());
+
+        Product product = productRepository.findByIdAndDeletedAtIsNull(command.getProductId())
+                .orElseThrow(() -> {
+                    log.warn("상품 수정 실패 - 상품 없음, companyId: {}", command.getCompanyId());
+                    return new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND);
+                });
+
+        // 상품 companyId로 company 검증
+        CompanyInfo company = validateCompany(product.getCompanyId());
+
+        // companyId 변경 차단 — MASTER만 허용
+        if (!ROLE_MASTER.equals(command.getRequesterRole()) && command.getCompanyId() != null) {
+            throw new BusinessException(ProductErrorCode.PRODUCT_ACCESS_DENIED);
+        }
+
+        // hubId 수정 차단 - MASTER만 허용
+        if (!ROLE_MASTER.equals(command.getRequesterRole()) && command.getHubId() != null) {
+            throw new BusinessException(ProductErrorCode.PRODUCT_ACCESS_DENIED);
+        }
+
+        // 변경하려는 hubId가 있을 시 내부 API로 실존 검증
+        if (command.getHubId() != null) {
+            validateHub(command.getHubId());
+        }
+
+        // 권한 검증 (내부 메서드)
+        validateAuthority(
+                command.getRequesterId(),
+                command.getRequesterRole(),
+                command.getRequesterHubId(),
+                product.getHubId(),
+                company);
+
+        product.update(
+                command.getName(),
+                command.getPrice(),
+                command.getStatus(),
+                command.getCompanyId(),
+                command.getHubId()
+                );
+
+        log.info("상품 정보 수정 완료 - productId: {}", command.getProductId());
+        return GetProductResult.from(product);
+    }
+
+    @Transactional
+    public GetProductResult updateStock(UpdateProductStockCommand command) {
+        log.info("재고 수정 요청 - productId: {}, requester: {}, role: {}",
+                command.getProductId(), command.getRequesterId(), command.getRequesterRole());
+
+        // 상품 + 재고 함께 조회 (JOIN FETCH)
+        Product product = productRepository.findByIdWithStock(command.getProductId())
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        // 재고 수정은 MASTER, HUB_MANAGER만 가능 - COMPANY_MANAGER는 차단
+        // validateAuthority는 COMPANY_MANAGER를 허용하므로 사전에 차단
+        if (ROLE_COMPANY_MANAGER.equals(command.getRequesterRole())) {
+            throw new BusinessException(ProductErrorCode.PRODUCT_ACCESS_DENIED);
+        }
+
+        // 역할별 권한 검증 (HUB_MANAGER: 담당 허브 소속 상품만)
+        validateAuthority(
+                command.getRequesterId(),
+                command.getRequesterRole(),
+                command.getRequesterHubId(),
+                product.getHubId(),
+                null); // COMPANY_MANAGER는 차단했으므로 company 불필요
+
+        // 재고 수정
+        product.getStock().updateStock(command.getStock());
+
+        log.info("재고 수정 완료 - productId: {}, newStock: {}", command.getProductId(), command.getStock());
+        return GetProductResult.from(product);
+    }
+
+    @Transactional
+    public DeleteProductResult deleteProduct(DeleteProductCommand command) {
+        log.info("상품 삭제 요청 - productId: {}, requester: {}, role: {}",
+                command.getProductId(), command.getRequesterId(), command.getRequesterRole());
+
+        // 상품 + 재고 함께 조회 - 재고도 함께 연쇄적으로 삭제해야함
+        Product product = productRepository.findByIdWithStock(command.getProductId())
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        // 삭제는 MASTER, HUB_MANAGER만 가능
+        if (ROLE_COMPANY_MANAGER.equals(command.getRequesterRole())) {
+            throw new BusinessException(ProductErrorCode.PRODUCT_ACCESS_DENIED);
+        }
+
+        // 역할별 권한 검증 (HUB_MANAGER: 담당 허브 소속 상품만)
+        // company는 COMPANY_MANAGER 차단으로 인해 불필요
+        validateAuthority(
+                command.getRequesterId(),
+                command.getRequesterRole(),
+                command.getRequesterHubId(),
+                product.getHubId(),
+                null
+        );
+
+        // Product Soft Delete
+        product.softDelete(command.getRequesterId());
+
+        // ProductStock도 함께 Soft Delete - 상품과 재고는 생명주기가 동일
+        product.getStock().softDelete(command.getRequesterId());
+
+        log.info("상품 삭제 완료 - productId: {}", command.getProductId());
+        return DeleteProductResult.from(product);
+    }
+
+    // 내부 API 아웃바운드 - 상품 단건 조회
+    public GetProductResult getProductInternal(UUID productId) {
+        return GetProductResult.from(
+                productRepository.findByIdWithStock(productId)
+                        .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND))
+        );
+    }
+
+    // 내부 API 아웃바운드 - 재고 차감 (주문 생성 시 order-service 호출)
+    // @Version 낙관적 락 — 동시 차감 충돌 시 OptimisticLockException 발생
+    @Transactional
+    public StockChangeResult decreaseStock(UUID productId, Integer quantity) {
+        Product product = productRepository.findByIdWithStock(productId)
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        int newStock = product.getStock().getStock() - quantity;
+
+        // 재고 부족 - 0 미만 방지
+        if (newStock < 0) {
+            throw new BusinessException(ProductErrorCode.STOCK_NOT_ENOUGH);
+        }
+
+        product.getStock().updateStock(newStock);
+        log.info("재고 차감 완료 - productId: {}, 차감: {}, 잔여: {}", productId, quantity, newStock);
+        return StockChangeResult.from(product);
+    }
+
+    // 내부 API 아웃바운드 - 재고 복원 (주문 취소 시 order-service 호출)
+    // order-service가 원래 수량을 그대로 전달 후 stock += quantity
+    @Transactional
+    public StockChangeResult restoreStock(UUID productId, Integer quantity) {
+        Product product = productRepository.findByIdWithStock(productId)
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        int newStock = product.getStock().getStock() + quantity;
+        product.getStock().updateStock(newStock);
+        log.info("재고 복원 완료 - productId: {}, 복원: {}, 잔여: {}", productId, quantity, newStock);
+        return StockChangeResult.from(product);
+    }
+
+    // 내부 API 아웃바운드 - 업체 소속 상품 일괄 Soft Delete (업체 삭제 시 company-service 호출)
+    // 결과 없어도 deletedCount: 0 / 200 OK 반환 (멱등성 보장)
+    @Transactional
+    public BulkDeleteResult deleteProductsByCompany(UUID companyId, UUID deletedBy) {
+        List<Product> products = productRepository.findAllByCompanyIdWithStock(companyId);
+        LocalDateTime deletedAt = LocalDateTime.now();
+
+        // 각 상품과 재고를 함께 Soft Delete — 생명주기 동일
+        for (Product product : products) {
+            product.softDelete(deletedBy);
+            product.getStock().softDelete(deletedBy);
+        }
+
+        log.info("업체 소속 상품 일괄 삭제 완료 - companyId: {}, 삭제 수: {}", companyId, products.size());
+        return BulkDeleteResult.builder()
+                .companyId(companyId)
+                .deletedCount(products.size())
+                .deletedAt(deletedAt)
+                .build();
+    }
+
+    // 내부 API 인바운드 - 업체 존재 여부 검증 (By. company-service)
+    private CompanyInfo validateCompany(UUID companyId) {
+        CompanyResponse companyResponse = companyClient.getCompany(companyId, INTERNAL_REQUEST).getData();
+        if (companyResponse == null) {
+            throw new BusinessException(ProductErrorCode.COMPANY_NOT_FOUND);
+        }
+        return CompanyInfo.from(companyResponse); // Infrastructure DTO → Application 변환
+    }
+
+    // 내부 API 인바운드 - 허브 존재 여부 검증 (By. hub-service)
+    private void validateHub (UUID hubId) {
+        HubResponse hub = hubClient.getHub(hubId, INTERNAL_REQUEST).getData();
+        if (hub == null) {
+            throw new BusinessException(ProductErrorCode.HUB_NOT_FOUND);
+        }
+    }
+
+    // 역할별 권한 검증
+    private void validateAuthority(
+            UUID requesterId,
+            String requesterRole,
+            UUID requesterHubId,
+            UUID targetHubId,
+            CompanyInfo company
+    ) {
+        if (ROLE_MASTER.equals(requesterRole)) {
+            // MASTER : 제한 없음
+            return;
+        }
+
+        if (ROLE_HUB_MANAGER.equals(requesterRole)) {
+            // HUB_MANAGER: 담당 허브 소속 상품만 조작 가능
+            if (!requesterHubId.equals(targetHubId)) {
+                throw new BusinessException(ProductErrorCode.PRODUCT_NOT_ALLOWED);
+            }
+            return;
+        }
+
+        if (ROLE_COMPANY_MANAGER.equals(requesterRole)) {
+            // COMPANY_MANAGER: 본인 업체 상품만 조작 가능
+            if (!requesterId.equals(company.manager())) {
+                throw new BusinessException(ProductErrorCode.PRODUCT_ACCESS_DENIED);
+            }
+            return;
+        }
+
+        // 위 역할 외에는 모두 거부
+        throw new BusinessException(ProductErrorCode.PRODUCT_ACCESS_DENIED);
+    }
+
+
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/application/ProductService.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/application/ProductService.java
@@ -88,6 +88,10 @@ public class ProductService {
             Pageable pageable) {
 
         // HUB_MANAGER는 담당 허브 소속 상품만 조회 가능 — 자동으로 hubId 필터 적용
+        // requesterHubId null 방어 — null이면 hubFilter=null이 되어 전체 조회로 열리는 버그 방지
+        if (ROLE_HUB_MANAGER.equals(requesterRole) && requesterHubId == null) {
+            throw new BusinessException(ProductErrorCode.PRODUCT_NOT_ALLOWED);
+        }
         UUID hubFilter = ROLE_HUB_MANAGER.equals(requesterRole) ? requesterHubId : null;
 
         return productRepository

--- a/product-service/src/main/java/com/sparta/lucky/product/application/ProductService.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/application/ProductService.java
@@ -7,6 +7,7 @@ import com.sparta.lucky.product.infrastructure.feign.CompanyClient;
 import com.sparta.lucky.product.infrastructure.feign.HubClient;
 import com.sparta.lucky.product.infrastructure.feign.dto.CompanyResponse;
 import com.sparta.lucky.product.infrastructure.feign.dto.HubResponse;
+import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -69,11 +70,11 @@ public class ProductService {
 
         // Product 저장 후 생성된 Id를 바탕으로 ProductStock 생성 및 저장
         // 같은 트랜잭션 - product 저장 실패시 함께 롤백
+        // version 초기화는 JPA @Version이 자동 처리하므로 명시적 설정 불필요
         ProductStock stock = ProductStock.builder()
                 .product(product)
                 .hubId(product.getHubId())
                 .stock(command.getStock())
-                .version(0L)
                 .build();
         productStockRepository.save(stock);
 
@@ -130,6 +131,11 @@ public class ProductService {
         // hubId 수정 차단 - MASTER만 허용
         if (!ROLE_MASTER.equals(command.getRequesterRole()) && command.getHubId() != null) {
             throw new BusinessException(ProductErrorCode.PRODUCT_ACCESS_DENIED);
+        }
+
+        // MASTER가 companyId를 변경하는 경우 — 새 업체가 실제 존재하는지 검증
+        if (command.getCompanyId() != null) {
+            validateCompany(command.getCompanyId());
         }
 
         // 변경하려는 hubId가 있을 시 내부 API로 실존 검증
@@ -233,6 +239,11 @@ public class ProductService {
     // @Version 낙관적 락 — 동시 차감 충돌 시 OptimisticLockException 발생
     @Transactional
     public StockChangeResult decreaseStock(UUID productId, Integer quantity) {
+        // 음수·0 수량 방어
+        if (quantity == null || quantity <= 0) {
+            throw new BusinessException(ProductErrorCode.INVALID_STOCK_QUANTITY);
+        }
+
         Product product = productRepository.findByIdWithStock(productId)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
@@ -252,6 +263,11 @@ public class ProductService {
     // order-service가 원래 수량을 그대로 전달 후 stock += quantity
     @Transactional
     public StockChangeResult restoreStock(UUID productId, Integer quantity) {
+        // 음수·0 수량 방어
+        if (quantity == null || quantity <= 0) {
+            throw new BusinessException(ProductErrorCode.INVALID_STOCK_QUANTITY);
+        }
+
         Product product = productRepository.findByIdWithStock(productId)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
@@ -266,7 +282,6 @@ public class ProductService {
     @Transactional
     public BulkDeleteResult deleteProductsByCompany(UUID companyId, UUID deletedBy) {
         List<Product> products = productRepository.findAllByCompanyIdWithStock(companyId);
-        LocalDateTime deletedAt = LocalDateTime.now();
 
         // 각 상품과 재고를 함께 Soft Delete — 생명주기 동일
         for (Product product : products) {
@@ -278,24 +293,53 @@ public class ProductService {
         return BulkDeleteResult.builder()
                 .companyId(companyId)
                 .deletedCount(products.size())
-                .deletedAt(deletedAt)
+                .deletedAt(LocalDateTime.now())
                 .build();
     }
 
     // 내부 API 인바운드 - 업체 존재 여부 검증 (By. company-service)
     private CompanyInfo validateCompany(UUID companyId) {
-        CompanyResponse companyResponse = companyClient.getCompany(companyId, INTERNAL_REQUEST).getData();
-        if (companyResponse == null) {
+        log.info("[Feign] company-service 업체 검증 요청 - companyId: {}", companyId);
+        try {
+            CompanyResponse companyResponse = companyClient.getCompany(companyId, INTERNAL_REQUEST).getData();
+            if (companyResponse == null) {
+                // 정상 응답이지만 data가 null인 경우 (비정상 계약)
+                log.warn("[Feign] company-service 응답 data=null - companyId: {}", companyId);
+                throw new BusinessException(ProductErrorCode.COMPANY_NOT_FOUND);
+            }
+            log.info("[Feign] company-service 업체 검증 성공 - companyId: {}, name: {}", companyId, companyResponse.getName());
+            return CompanyInfo.from(companyResponse); // Infrastructure DTO → Application 변환
+        } catch (FeignException.NotFound e) {
+            // company-service가 404 반환 — 해당 업체 없음
+            log.warn("[Feign] company-service 업체 없음 (404) - companyId: {}", companyId);
             throw new BusinessException(ProductErrorCode.COMPANY_NOT_FOUND);
+        } catch (FeignException e) {
+            // 그 외 네트워크 오류, 서비스 다운 등
+            log.error("[Feign] company-service 호출 실패 - companyId: {}, status: {}, message: {}",
+                    companyId, e.status(), e.getMessage());
+            throw e;
         }
-        return CompanyInfo.from(companyResponse); // Infrastructure DTO → Application 변환
     }
 
     // 내부 API 인바운드 - 허브 존재 여부 검증 (By. hub-service)
-    private void validateHub (UUID hubId) {
-        HubResponse hub = hubClient.getHub(hubId, INTERNAL_REQUEST).getData();
-        if (hub == null) {
+    private void validateHub(UUID hubId) {
+        log.info("[Feign] hub-service 허브 검증 요청 - hubId: {}", hubId);
+        try {
+            HubResponse hub = hubClient.getHub(hubId, INTERNAL_REQUEST).getData();
+            if (hub == null) {
+                // 정상 응답이지만 data가 null인 경우
+                log.warn("[Feign] hub-service 응답 data=null - hubId: {}", hubId);
+                throw new BusinessException(ProductErrorCode.HUB_NOT_FOUND);
+            }
+            log.info("[Feign] hub-service 허브 검증 성공 - hubId: {}, name: {}", hubId, hub.getName());
+        } catch (FeignException.NotFound e) {
+            // hub-service가 404 반환 — 해당 허브 없음
+            log.warn("[Feign] hub-service 허브 없음 (404) - hubId: {}", hubId);
             throw new BusinessException(ProductErrorCode.HUB_NOT_FOUND);
+        } catch (FeignException e) {
+            log.error("[Feign] hub-service 호출 실패 - hubId: {}, status: {}, message: {}",
+                    hubId, e.status(), e.getMessage());
+            throw e;
         }
     }
 
@@ -314,7 +358,8 @@ public class ProductService {
 
         if (ROLE_HUB_MANAGER.equals(requesterRole)) {
             // HUB_MANAGER: 담당 허브 소속 상품만 조작 가능
-            if (!requesterHubId.equals(targetHubId)) {
+            // requesterHubId null 방어
+            if (requesterHubId == null || !requesterHubId.equals(targetHubId)) {
                 throw new BusinessException(ProductErrorCode.PRODUCT_NOT_ALLOWED);
             }
             return;

--- a/product-service/src/main/java/com/sparta/lucky/product/application/ProductService.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/application/ProductService.java
@@ -271,7 +271,15 @@ public class ProductService {
         Product product = productRepository.findByIdWithStock(productId)
                 .orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
-        int newStock = product.getStock().getStock() + quantity;
+        int currentStock = product.getStock().getStock();
+
+        // int 오버플로우 방지 - currentStock + quantity가 Integer.MAX_VALUE 초과 시 음수로 wrap-around
+        if (currentStock > Integer.MAX_VALUE - quantity) {
+            log.warn("재고 오버플로우 감지 - productId: {}, currentStock: {}, quantity: {}", productId, currentStock, quantity);
+            throw new BusinessException(ProductErrorCode.STOCK_OVERFLOW);
+        }
+
+        int newStock = currentStock + quantity;
         product.getStock().updateStock(newStock);
         log.info("재고 복원 완료 - productId: {}, 복원: {}, 잔여: {}", productId, quantity, newStock);
         return StockChangeResult.from(product);

--- a/product-service/src/main/java/com/sparta/lucky/product/application/dto/CompanyInfo.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/application/dto/CompanyInfo.java
@@ -1,0 +1,14 @@
+package com.sparta.lucky.product.application.dto;
+
+import com.sparta.lucky.product.infrastructure.feign.dto.CompanyResponse;
+
+import java.util.UUID;
+
+public record CompanyInfo(UUID id, UUID hubId, UUID manager) {
+
+    // Infrastructure DTO → Application Info로 변환
+    // Application에 Infrastructure DTO를 그대로 전달하는 것을 방지
+    public static CompanyInfo from(CompanyResponse response) {
+        return new CompanyInfo(response.getId(), response.getHubId(), response.getManager());
+    }
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/application/dto/CreateProductCommand.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/application/dto/CreateProductCommand.java
@@ -1,0 +1,21 @@
+package com.sparta.lucky.product.application.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+public class CreateProductCommand {
+    private final UUID companyId;
+    private final UUID hubId;
+    private final String name;
+    private final Integer price;
+    private final Integer stock;
+
+    // 소유권 검증용 — Gateway 헤더에서 추출
+    private final UUID requesterId;
+    private final String requesterRole;
+    private final UUID requesterHubId;  // HUB_MANAGER: 자기 허브에만 생성 가능
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/application/dto/CreateProductResult.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/application/dto/CreateProductResult.java
@@ -1,0 +1,39 @@
+package com.sparta.lucky.product.application.dto;
+
+import com.sparta.lucky.product.domain.Product;
+import com.sparta.lucky.product.domain.ProductStatus;
+import com.sparta.lucky.product.domain.ProductStock;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class CreateProductResult {
+    private final UUID id;
+    private final UUID companyId;
+    private final UUID hubId;
+    private final String name;
+    private final Integer price;
+    private final ProductStatus status;
+    private final Integer stock;
+    private final LocalDateTime createdAt;
+    private final UUID createdBy;
+
+    // Entity → Result 변환 팩토리 메서드
+    public static CreateProductResult from(Product product, ProductStock stock) {
+        return CreateProductResult.builder()
+                .id(product.getId())
+                .companyId(product.getCompanyId())
+                .hubId(product.getHubId())
+                .name(product.getName())
+                .price(product.getPrice())
+                .status(product.getStatus())
+                .stock(stock.getStock())
+                .createdAt(product.getCreatedAt())
+                .createdBy(product.getCreatedBy())
+                .build();
+    }
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/application/dto/DeleteProductCommand.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/application/dto/DeleteProductCommand.java
@@ -1,0 +1,15 @@
+package com.sparta.lucky.product.application.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+public class DeleteProductCommand {
+    private final UUID productId;
+    private final UUID requesterId;
+    private final String requesterRole;
+    private final UUID requesterHubId;
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/application/dto/DeleteProductResult.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/application/dto/DeleteProductResult.java
@@ -1,0 +1,24 @@
+package com.sparta.lucky.product.application.dto;
+
+import com.sparta.lucky.product.domain.Product;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class DeleteProductResult {
+    private final UUID id;
+    private final LocalDateTime deletedAt;
+    private final UUID deletedBy;
+
+    public static DeleteProductResult from(Product product) {
+        return DeleteProductResult.builder()
+                .id(product.getId())
+                .deletedAt(product.getDeletedAt())
+                .deletedBy(product.getDeletedBy())
+                .build();
+    }
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/application/dto/GetProductResult.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/application/dto/GetProductResult.java
@@ -22,6 +22,10 @@ public class GetProductResult {
     private final LocalDateTime updatedAt;
 
     public static GetProductResult from(Product product) {
+        // JOIN FETCH로 stock이 함께 로딩되어야 정상 — null이면 데이터 무결성 문제
+        if (product.getStock() == null) {
+            throw new IllegalStateException("ProductStock 데이터가 없습니다. productId=" + product.getId());
+        }
         return GetProductResult.builder()
                 .id(product.getId())
                 .companyId(product.getCompanyId())
@@ -29,7 +33,7 @@ public class GetProductResult {
                 .name(product.getName())
                 .price(product.getPrice())
                 .status(product.getStatus())
-                .stock(product.getStock().getStock()) // JOIN FETCH로 이미 로딩됨
+                .stock(product.getStock().getStock())
                 .createdAt(product.getCreatedAt())
                 .updatedAt(product.getUpdatedAt())
                 .build();

--- a/product-service/src/main/java/com/sparta/lucky/product/application/dto/GetProductResult.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/application/dto/GetProductResult.java
@@ -1,0 +1,37 @@
+package com.sparta.lucky.product.application.dto;
+
+import com.sparta.lucky.product.domain.Product;
+import com.sparta.lucky.product.domain.ProductStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class GetProductResult {
+    private final UUID id;
+    private final UUID companyId;
+    private final UUID hubId;
+    private final String name;
+    private final Integer price;
+    private final ProductStatus status;
+    private final Integer stock;           // stock 포함
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public static GetProductResult from(Product product) {
+        return GetProductResult.builder()
+                .id(product.getId())
+                .companyId(product.getCompanyId())
+                .hubId(product.getHubId())
+                .name(product.getName())
+                .price(product.getPrice())
+                .status(product.getStatus())
+                .stock(product.getStock().getStock()) // JOIN FETCH로 이미 로딩됨
+                .createdAt(product.getCreatedAt())
+                .updatedAt(product.getUpdatedAt())
+                .build();
+    }
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/application/dto/UpdateProductCommand.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/application/dto/UpdateProductCommand.java
@@ -1,0 +1,31 @@
+package com.sparta.lucky.product.application.dto;
+
+
+import com.sparta.lucky.product.domain.ProductStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+public class UpdateProductCommand {
+
+    private final UUID productId;
+
+    // null이면 해당 필드 미변경
+    private final String name;
+    private final Integer price;
+    private final ProductStatus status;
+    private final UUID companyId;
+    private final UUID hubId;
+
+    // JWT 파싱 데이터는 요청자 기준 > requester로 표기합니다
+    // 소유권 검증용
+    private final UUID requesterId;
+    private final String requesterRole;
+    private final UUID requesterHubId;     // HUB_MANAGER 검증
+    private final UUID requesterCompanyId; // COMPANY_MANAGER 검증
+
+
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/application/dto/UpdateProductStockCommand.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/application/dto/UpdateProductStockCommand.java
@@ -1,0 +1,16 @@
+package com.sparta.lucky.product.application.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+public class UpdateProductStockCommand {
+    private final UUID productId;
+    private final Integer stock;
+    private final UUID requesterId;
+    private final String requesterRole;
+    private final UUID requesterHubId;
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/common/exception/GlobalExceptionHandler.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.sparta.lucky.product.common.exception;
 
 import com.sparta.lucky.product.common.response.ApiResponse;
+import com.sparta.lucky.product.domain.ProductErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -52,12 +53,15 @@ public class GlobalExceptionHandler {
     }
 
     // 낙관적 락 충돌 — 동시 재고 차감 시 발생, order-service 재시도 필요 - 409
+    // 에러 코드/메시지는 ProductErrorCode.STOCK_CONFLICT에서 단일 관리 (하드코딩 방지)
     @ExceptionHandler(org.springframework.orm.ObjectOptimisticLockingFailureException.class)
     public ResponseEntity<ApiResponse<Void>> handleOptimisticLock(
             org.springframework.orm.ObjectOptimisticLockingFailureException e) {
         log.warn("[OptimisticLock] 재고 동시 수정 충돌 발생: {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.CONFLICT)
-                .body(ApiResponse.error("PRODUCT_007", "재고 동시 수정 충돌 발생. 다시 시도해주세요."));
+                .body(ApiResponse.error(
+                        ProductErrorCode.STOCK_CONFLICT.getCode(),
+                        ProductErrorCode.STOCK_CONFLICT.getMessage()));
     }
 
     // 그 외 예상치 못한 서버 에러

--- a/product-service/src/main/java/com/sparta/lucky/product/common/exception/GlobalExceptionHandler.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/common/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.sparta.lucky.product.common.exception;
 
 import com.sparta.lucky.product.common.response.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
@@ -48,6 +49,15 @@ public class GlobalExceptionHandler {
         log.warn("[BadRequest] type={}", e.getClass().getSimpleName());
         return ResponseEntity.badRequest()
                 .body(ApiResponse.error("VALIDATION_003", "요청 형식이 올바르지 않습니다."));
+    }
+
+    // 낙관적 락 충돌 — 동시 재고 차감 시 발생, order-service 재시도 필요 - 409
+    @ExceptionHandler(org.springframework.orm.ObjectOptimisticLockingFailureException.class)
+    public ResponseEntity<ApiResponse<Void>> handleOptimisticLock(
+            org.springframework.orm.ObjectOptimisticLockingFailureException e) {
+        log.warn("[OptimisticLock] 재고 동시 수정 충돌 발생: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ApiResponse.error("PRODUCT_007", "재고 동시 수정 충돌 발생. 다시 시도해주세요."));
     }
 
     // 그 외 예상치 못한 서버 에러

--- a/product-service/src/main/java/com/sparta/lucky/product/domain/Product.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/domain/Product.java
@@ -1,0 +1,60 @@
+package com.sparta.lucky.product.domain;
+
+import com.sparta.lucky.product.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.util.Objects;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_product")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Product extends BaseEntity {
+
+    @Id
+    @GeneratedValue
+    @UuidGenerator
+    @Column(updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(columnDefinition = "uuid", nullable = false)
+    private UUID companyId; // 상품 소속 업체
+
+    @Column(columnDefinition = "uuid", nullable = false)
+    private UUID hubId; // 상품 소속 허브 ID
+
+    @Column(name = "name", length = 100, nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private Integer price;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 10, nullable = false)
+    private ProductStatus  status;
+
+    // ProductStock이 연관관계 주인 (product_id 컬럼을 ProductStock이 가짐)
+    @OneToOne(mappedBy = "product", fetch = FetchType.LAZY)
+    private ProductStock stock;
+
+    // 도메인 메서드
+
+    /**
+     * 기본 정보 수정 (MASTER, HUB_MANAGER, COMPANY_MANAGER 공통)
+     * null 값은 무시 — 전달된 필드만 업데이트
+     */
+    public void update(String name, Integer price, ProductStatus status, UUID companyId, UUID hubId) {
+        if (name != null) this.name = name;
+        if (price != null) this.price = price;
+        if (status != null) this.status = status;
+        if (companyId != null) this.companyId = companyId;
+        if (hubId != null) this.hubId = hubId;
+    }
+
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/domain/ProductErrorCode.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/domain/ProductErrorCode.java
@@ -14,7 +14,9 @@ public enum ProductErrorCode implements ErrorCode {
     PRODUCT_NOT_ALLOWED("PRODUCT_004", "담당 허브의 상품이 아닙니다.", 403),
     PRODUCT_NOT_FOUND("PRODUCT_005", "해당 상품을 찾을 수 없습니다.", 404),
     STOCK_NOT_ENOUGH("PRODUCT_006", "재고가 부족합니다.", 409),
-    STOCK_CONFLICT("PRODUCT_007", "재고 동시 수정 충돌 발생. 다시 시도해주세요.", 409);
+    STOCK_CONFLICT("PRODUCT_007", "재고 동시 수정 충돌 발생. 다시 시도해주세요.", 409),
+    // 차감/복원 요청 수량이 0 이하인 경우 — 음수 수량으로 인한 재고 증가·감소 버그 방지
+    INVALID_STOCK_QUANTITY("PRODUCT_008", "수량은 1 이상이어야 합니다.", 400);
 
     private final String code;
     private final String message;

--- a/product-service/src/main/java/com/sparta/lucky/product/domain/ProductErrorCode.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/domain/ProductErrorCode.java
@@ -1,0 +1,22 @@
+package com.sparta.lucky.product.domain;
+
+import com.sparta.lucky.product.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProductErrorCode implements ErrorCode {
+
+    COMPANY_NOT_FOUND("PRODUCT_001", "해당 업체를 찾을 수 없습니다.", 404),
+    HUB_NOT_FOUND("PRODUCT_002", "해당 허브를 찾을 수 없습니다.", 404),
+    PRODUCT_ACCESS_DENIED("PRODUCT_003", "본인 업체의 상품이 아닙니다.", 403),
+    PRODUCT_NOT_ALLOWED("PRODUCT_004", "담당 허브의 상품이 아닙니다.", 403),
+    PRODUCT_NOT_FOUND("PRODUCT_005", "해당 상품을 찾을 수 없습니다.", 404),
+    STOCK_NOT_ENOUGH("PRODUCT_006", "재고가 부족합니다.", 409),
+    STOCK_CONFLICT("PRODUCT_007", "재고 동시 수정 충돌 발생. 다시 시도해주세요.", 409);
+
+    private final String code;
+    private final String message;
+    private final int httpStatus;
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/domain/ProductErrorCode.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/domain/ProductErrorCode.java
@@ -16,7 +16,9 @@ public enum ProductErrorCode implements ErrorCode {
     STOCK_NOT_ENOUGH("PRODUCT_006", "재고가 부족합니다.", 409),
     STOCK_CONFLICT("PRODUCT_007", "재고 동시 수정 충돌 발생. 다시 시도해주세요.", 409),
     // 차감/복원 요청 수량이 0 이하인 경우 — 음수 수량으로 인한 재고 증가·감소 버그 방지
-    INVALID_STOCK_QUANTITY("PRODUCT_008", "수량은 1 이상이어야 합니다.", 400);
+    INVALID_STOCK_QUANTITY("PRODUCT_008", "수량은 1 이상이어야 합니다.", 400),
+    // 재고 복원 시 int 최대값 초과 방지 - currentStock + quantity > Integer.MAX_VALUE
+    STOCK_OVERFLOW("PRODUCT_009", "재고가 최대값을 초과합니다.", 400);
 
     private final String code;
     private final String message;

--- a/product-service/src/main/java/com/sparta/lucky/product/domain/ProductRepository.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/domain/ProductRepository.java
@@ -1,0 +1,29 @@
+package com.sparta.lucky.product.domain;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+// Application 레이어가 의존하는 인터페이스 (DIP 적용)
+// JPA 구현체는 infrastructure 레이어에 위치
+public interface ProductRepository {
+
+    Product save(Product product);
+
+    Optional<Product> findByIdAndDeletedAtIsNull(UUID id);
+
+    // 목록 조회(검색)
+    Page<Product> findAllWithStock(
+            String name, ProductStatus status, UUID companyId, UUID hubId, Pageable pageable);
+
+    Optional<Product> findByIdWithStock(UUID productId);
+
+    // 업체 소속 상품 + 재고 일괄 조회 (Soft Delete 미완료 건만 해당)
+    List<Product> findAllByCompanyIdWithStock(UUID companyId);
+
+
+
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/domain/ProductStatus.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/domain/ProductStatus.java
@@ -1,0 +1,6 @@
+package com.sparta.lucky.product.domain;
+
+public enum ProductStatus {
+    ACTIVE,
+    INACTIVE
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/domain/ProductStock.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/domain/ProductStock.java
@@ -1,0 +1,49 @@
+package com.sparta.lucky.product.domain;
+
+import com.sparta.lucky.product.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_product_stock")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProductStock extends BaseEntity {
+
+    @Id
+    @GeneratedValue
+    @UuidGenerator
+    @Column(updatable = false, nullable = false)
+    private UUID id;
+
+    // UUID productId -> JPA관계로 대체
+    // @JoinColumn이 product_id 컬럼을 생성
+    // product 목록 검색시 N+1 문제를 방지하기 위함
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", columnDefinition = "uuid", nullable = false, updatable = false)
+    private Product product;
+
+    @Column(columnDefinition = "uuid", nullable = false)
+    private UUID hubId; // 상품 소속 허브 ID
+
+    @Column(nullable = false)
+    private Integer stock;
+
+    @Version // 낙관적 락 - 충돌시 OptimisticLockException 발생
+    @Column(nullable = false)
+    private Long version;
+
+    // 재고 절대값으로 수정 (외부 API용)
+    public void updateStock(Integer newStock) {
+        this.stock = newStock;
+    }
+
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/domain/ProductStock.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/domain/ProductStock.java
@@ -42,7 +42,11 @@ public class ProductStock extends BaseEntity {
     private Long version;
 
     // 재고 절대값으로 수정 (외부 API용)
+    // 도메인 불변식: 재고는 반드시 0 이상
     public void updateStock(Integer newStock) {
+        if (newStock == null || newStock < 0) {
+            throw new IllegalArgumentException("재고는 0 이상이어야 합니다. 입력값: " + newStock);
+        }
         this.stock = newStock;
     }
 

--- a/product-service/src/main/java/com/sparta/lucky/product/domain/ProductStockRepository.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/domain/ProductStockRepository.java
@@ -1,0 +1,7 @@
+package com.sparta.lucky.product.domain;
+
+public interface ProductStockRepository {
+
+    ProductStock save(ProductStock stock);
+
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/infrastructure/ProductJpaRepository.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/infrastructure/ProductJpaRepository.java
@@ -1,0 +1,45 @@
+package com.sparta.lucky.product.infrastructure;
+
+import com.sparta.lucky.product.domain.Product;
+import com.sparta.lucky.product.domain.ProductStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+interface ProductJpaRepository extends JpaRepository<Product, UUID> {
+
+    Optional<Product> findByIdAndDeletedAtIsNull(UUID id);
+
+    // product 목록 페이지 조회
+    @Query("SELECT p FROM Product p JOIN FETCH p.stock ps WHERE " +
+            "(:name IS NULL OR p.name LIKE %:name%) AND " +
+            "(:status IS NULL OR p.status = :status) AND " +
+            "(:companyId IS NULL OR p.companyId = :companyId) AND " +
+            "(:hubId IS NULL OR p.hubId = :hubId) AND " +
+            "p.deletedAt IS NULL AND ps.deletedAt IS NULL")
+    Page<Product> findAllWithStock(
+            @Param("name") String name,
+            @Param("status") ProductStatus status,
+            @Param("companyId") UUID companyId,
+            @Param("hubId") UUID hubId,
+            Pageable pageable
+    );
+
+    // id로 단건조회 + stock JOIN FETCH + soft delete 필터
+    @Query("SELECT p FROM Product p JOIN FETCH p.stock ps WHERE " +
+            "p.id = :productId AND p.deletedAt IS NULL AND ps.deletedAt IS NULL")
+    Optional<Product> findByIdWithStock(@Param("productId") UUID productId);
+
+    // 업체 소속 상품 + 재고 JOIN FETCH - 업체 삭제시 상품 일괄 Soft Delete용
+    @Query("SELECT p FROM Product p JOIN FETCH p.stock ps " +
+            "WHERE p.companyId = :companyId AND p.deletedAt IS NULL AND ps.deletedAt IS NULL")
+    List<Product> findAllByCompanyIdWithStock(@Param("companyId") UUID companyId);
+
+
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/infrastructure/ProductRepositoryImpl.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/infrastructure/ProductRepositoryImpl.java
@@ -1,0 +1,48 @@
+package com.sparta.lucky.product.infrastructure;
+
+import com.sparta.lucky.product.domain.Product;
+import com.sparta.lucky.product.domain.ProductRepository;
+import com.sparta.lucky.product.domain.ProductStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductRepositoryImpl implements ProductRepository {
+
+    private final ProductJpaRepository productJpaRepository;
+
+    @Override
+    public Product save(Product product) {
+        return productJpaRepository.save(product);
+    }
+
+    @Override
+    public Page<Product> findAllWithStock(
+            String name, ProductStatus status, UUID companyId, UUID hubId, Pageable pageable) {
+        return productJpaRepository.findAllWithStock(name, status, companyId, hubId, pageable);
+    }
+
+    @Override
+    public Optional<Product> findByIdWithStock(UUID productId) {
+        return productJpaRepository.findByIdWithStock(productId);
+    }
+
+    @Override
+    public List<Product> findAllByCompanyIdWithStock(UUID companyId) {
+        return productJpaRepository.findAllByCompanyIdWithStock(companyId);
+    }
+
+    @Override
+    public Optional<Product> findByIdAndDeletedAtIsNull(UUID id) {
+        return productJpaRepository.findByIdAndDeletedAtIsNull(id);
+    }
+
+
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/infrastructure/ProductStockJpaRepository.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/infrastructure/ProductStockJpaRepository.java
@@ -1,0 +1,15 @@
+package com.sparta.lucky.product.infrastructure;
+
+import com.sparta.lucky.product.domain.ProductStock;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+import java.util.UUID;
+
+interface ProductStockJpaRepository extends JpaRepository<ProductStock, UUID> {
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/infrastructure/ProductStockRepositoryImpl.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/infrastructure/ProductStockRepositoryImpl.java
@@ -1,0 +1,18 @@
+package com.sparta.lucky.product.infrastructure;
+
+import com.sparta.lucky.product.domain.ProductStock;
+import com.sparta.lucky.product.domain.ProductStockRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductStockRepositoryImpl implements ProductStockRepository {
+
+    private final ProductStockRepository productStockRepository;
+
+    @Override
+    public ProductStock save(ProductStock stock) {
+        return productStockRepository.save(stock);
+    }
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/infrastructure/ProductStockRepositoryImpl.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/infrastructure/ProductStockRepositoryImpl.java
@@ -9,10 +9,10 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class ProductStockRepositoryImpl implements ProductStockRepository {
 
-    private final ProductStockRepository productStockRepository;
+        private final ProductStockJpaRepository productStockJpaRepository;
 
     @Override
     public ProductStock save(ProductStock stock) {
-        return productStockRepository.save(stock);
+        return productStockJpaRepository.save(stock);
     }
 }

--- a/product-service/src/main/java/com/sparta/lucky/product/infrastructure/feign/CompanyClient.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/infrastructure/feign/CompanyClient.java
@@ -1,0 +1,20 @@
+package com.sparta.lucky.product.infrastructure.feign;
+
+import com.sparta.lucky.product.infrastructure.feign.dto.CompanyResponse;
+import com.sparta.lucky.product.infrastructure.feign.dto.FeignApiResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import java.util.UUID;
+
+@FeignClient(name = "company-service")
+public interface CompanyClient {
+
+    @GetMapping("/internal/api/v1/companies/{companyId}")
+    FeignApiResponse<CompanyResponse> getCompany(
+            @PathVariable UUID companyId,
+            @RequestHeader("X-Internal-Request") String internalRequest
+    );
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/infrastructure/feign/HubClient.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/infrastructure/feign/HubClient.java
@@ -1,0 +1,21 @@
+package com.sparta.lucky.product.infrastructure.feign;
+
+import com.sparta.lucky.product.infrastructure.feign.dto.FeignApiResponse;
+import com.sparta.lucky.product.infrastructure.feign.dto.HubResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import java.util.UUID;
+
+// Eureka 서비스명 -hub-service로 로드밸런싱
+@FeignClient(name = "hub-service")
+public interface HubClient {
+
+    @GetMapping("/internal/api/v1/hubs/{hubId}")
+    FeignApiResponse<HubResponse> getHub(
+            @PathVariable UUID hubId,
+            @RequestHeader("X-Internal-Request") String internalRequest  // 내부 요청 식별 헤더
+    );
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/infrastructure/feign/dto/CompanyResponse.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/infrastructure/feign/dto/CompanyResponse.java
@@ -1,0 +1,16 @@
+package com.sparta.lucky.product.infrastructure.feign.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+public class CompanyResponse {
+    private UUID id;
+    private UUID hubId;
+    private String name;
+    private String companyType;
+    private UUID manager; // 업체 담당자 - COMPANY_MANAGER 소유권 검증시 사용
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/infrastructure/feign/dto/FeignApiResponse.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/infrastructure/feign/dto/FeignApiResponse.java
@@ -1,0 +1,13 @@
+package com.sparta.lucky.product.infrastructure.feign.dto;
+
+// { "success": true, "data": {...} } 형태 응답 역직렬화 래퍼
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FeignApiResponse<T> {
+    private boolean success;
+    private T data;
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/infrastructure/feign/dto/HubResponse.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/infrastructure/feign/dto/HubResponse.java
@@ -1,0 +1,21 @@
+package com.sparta.lucky.product.infrastructure.feign.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+public class HubResponse {
+    private UUID hubId;
+    private UUID managerId;
+    private String name;
+    private String address;
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+    private LocalDateTime createdAt;
+    private UUID createdBy;
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/presentation/ProductController.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/presentation/ProductController.java
@@ -1,0 +1,208 @@
+package com.sparta.lucky.product.presentation;
+
+import com.sparta.lucky.product.application.ProductService;
+import com.sparta.lucky.product.application.dto.CreateProductCommand;
+import com.sparta.lucky.product.application.dto.DeleteProductCommand;
+import com.sparta.lucky.product.application.dto.UpdateProductCommand;
+import com.sparta.lucky.product.application.dto.UpdateProductStockCommand;
+import com.sparta.lucky.product.common.exception.BusinessException;
+import com.sparta.lucky.product.common.response.ApiResponse;
+import com.sparta.lucky.product.domain.ProductErrorCode;
+import com.sparta.lucky.product.domain.ProductStatus;
+import com.sparta.lucky.product.presentation.dto.*;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/products")
+@RequiredArgsConstructor
+public class ProductController {
+
+    private final ProductService productService;
+
+    /**
+     * 상품 생성
+     * [권한]
+     * - MASTER : 모두 가능
+     * - HUB_MANAGER : 담당 허브 소속 상품만 가능
+     * - COMPANY_MANAGER : 본인 업체 상품만 가능
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<PostProductResDto> createProduct(
+            @Valid @RequestBody PostProductReqDto reqDto,
+            @RequestHeader("X-User-Id") UUID userId,
+            @RequestHeader("X-User-Role") String userRole,
+            @RequestHeader(value = "X-Hub-Id", required = false) UUID hubId
+            ) {
+        validateHubHeader(userRole, hubId);
+        CreateProductCommand command = CreateProductCommand.builder()
+                .companyId(reqDto.getCompanyId())
+                .hubId(reqDto.getHubId())
+                .name(reqDto.getName())
+                .price(reqDto.getPrice())
+                .stock(reqDto.getStock())
+                .requesterId(userId)
+                .requesterRole(userRole)
+                .requesterHubId(hubId)
+                .build();
+
+        return ApiResponse.success(
+                PostProductResDto.from(productService.createProduct(command))
+        );
+    }
+
+    /**
+     * 상품 목록 조회 / 검색
+     * [권한]
+     * - 전체 로그인 사용자 가능
+     * - HUB_MANAGER: 담당 허브 소속 상품만 조회
+     */
+    @GetMapping
+    public ApiResponse<Page<GetProductResDto>> getProducts(
+            @RequestParam(required = false) String name,
+            @RequestParam(required = false) ProductStatus status,
+            @RequestParam(required = false) UUID companyId,
+            @RequestHeader("X-User-Role") String userRole,
+            @RequestHeader(value = "X-Hub-Id", required = false) UUID hubId,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        validateHubHeader(userRole, hubId);
+
+        int validSize = List.of(10, 30, 50).contains(pageable.getPageSize())
+                ? pageable.getPageSize() : 10;
+        Pageable validPageable = PageRequest.of(pageable.getPageNumber(), validSize, pageable.getSort());
+
+        return ApiResponse.success(
+                productService.getProducts(name, status, companyId, userRole, hubId, validPageable)
+                        .map(GetProductResDto::from)
+        );
+    }
+
+    /**
+     * 상품 단건 조회
+     * [권한]
+     * - 전체 로그인 사용자 가능
+     * - HUB_MANAGER: 담당 허브 소속 상품만 조회
+     */
+    @GetMapping("/{productId}")
+    public ApiResponse<GetProductResDto> getProduct(
+            @PathVariable UUID productId,
+            @RequestHeader("X-User-Role") String userRole,
+            @RequestHeader(value = "X-Hub-Id", required = false) UUID hubId
+    ) {
+        return ApiResponse.success(
+                GetProductResDto.from(productService.getProduct(productId, userRole, hubId))
+        );
+    }
+
+    /**
+     * 상품 수정 (재고 제외)
+     * [권한]
+     * - MASTER : 모두 가능
+     * - HUB_MANAGER : 담당 허브 소속 상품만 가능
+     * - COMPANY_MANAGER : 본인 업체 상품만 가능
+     */
+    @PatchMapping("/{productId}")
+    public ApiResponse<GetProductResDto> updateProductWithoutStock(
+            @PathVariable UUID productId,
+            @Valid @RequestBody PatchProductReqDto reqDto,
+            @RequestHeader("X-User-Id") UUID userId,
+            @RequestHeader("X-User-Role") String userRole,
+            @RequestHeader(value = "X-Hub-Id", required = false) UUID hubId,
+            @RequestHeader(value = "X-Company-Id", required = false) UUID companyIdHeader
+    ) {
+        validateHubHeader(userRole, hubId);
+        UpdateProductCommand command = UpdateProductCommand.builder()
+                .productId(productId)
+                .name(reqDto.getName())
+                .price(reqDto.getPrice())
+                .status(reqDto.getStatus())
+                .companyId(reqDto.getCompanyId())
+                .hubId(reqDto.getHubId())
+                .requesterId(userId)
+                .requesterRole(userRole)
+                .requesterHubId(hubId)
+                .requesterCompanyId(companyIdHeader)
+                .build();
+
+        return ApiResponse.success(
+                GetProductResDto.from(productService.updateProduct(command))
+        );
+
+    }
+
+    /**
+     * 재고 수정
+     * [권한]
+     * - MASTER : 모두 가능
+     * - HUB_MANAGER : 담당 허브 소속 상품만 가능
+     */
+    @PatchMapping("/{productId}/stock")
+    public ApiResponse<GetProductResDto> updateStock(
+            @PathVariable UUID productId,
+            @Valid @RequestBody PatchProductStockReqDto reqDto,
+            @RequestHeader("X-User-Id") UUID userId,
+            @RequestHeader("X-User-Role") String userRole,
+            @RequestHeader(value = "X-Hub-Id", required = false) UUID hubId
+    ) {
+        validateHubHeader(userRole, hubId);
+        UpdateProductStockCommand command = UpdateProductStockCommand.builder()
+                .productId(productId)
+                .stock(reqDto.getStock())
+                .requesterId(userId)
+                .requesterRole(userRole)
+                .requesterHubId(hubId)
+                .build();
+
+        return ApiResponse.success(
+                GetProductResDto.from(productService.updateStock(command))
+        );
+    }
+
+    /**
+     * 상품 삭제 (Soft Delete)
+     * [권한]
+     * - MASTER : 모두 가능
+     * - HUB_MANAGER : 담당 허브 소속 상품만 가능
+     */
+    @DeleteMapping("/{productId}")
+    public ApiResponse<DeleteProductResDto> deleteProduct(
+            @PathVariable UUID productId,
+            @RequestHeader("X-User-Id") UUID userId,
+            @RequestHeader("X-User-Role") String userRole,
+            @RequestHeader(value = "X-Hub-Id", required = false) UUID hubId
+    ) {
+        validateHubHeader(userRole, hubId);
+        DeleteProductCommand command = DeleteProductCommand.builder()
+                .productId(productId)
+                .requesterId(userId)
+                .requesterRole(userRole)
+                .requesterHubId(hubId)
+                .build();
+
+        return ApiResponse.success(
+                DeleteProductResDto.from(productService.deleteProduct(command))
+        );
+    }
+
+    // HUB_MANAGER 역할인데 X-Hub-Id 헤더가 없으면 즉시 거절 — 서비스 레이어 NPE 방지
+    private static final String ROLE_HUB_MANAGER = "HUB_MANAGER";
+    private void validateHubHeader(String userRole, UUID hubId) {
+        if (ROLE_HUB_MANAGER.equals(userRole) && hubId == null) {
+            throw new BusinessException(ProductErrorCode.PRODUCT_NOT_ALLOWED);
+        }
+    }
+
+
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/presentation/ProductController.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/presentation/ProductController.java
@@ -101,6 +101,8 @@ public class ProductController {
             @RequestHeader("X-User-Role") String userRole,
             @RequestHeader(value = "X-Hub-Id", required = false) UUID hubId
     ) {
+        // HUB_MANAGER가 X-Hub-Id 없이 단건 조회하면 서비스 레이어에서 NPE 발생 가능하므로 검증
+        validateHubHeader(userRole, hubId);
         return ApiResponse.success(
                 GetProductResDto.from(productService.getProduct(productId, userRole, hubId))
         );

--- a/product-service/src/main/java/com/sparta/lucky/product/presentation/dto/DeleteProductResDto.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/presentation/dto/DeleteProductResDto.java
@@ -1,0 +1,24 @@
+package com.sparta.lucky.product.presentation.dto;
+
+import com.sparta.lucky.product.application.dto.DeleteProductResult;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class DeleteProductResDto {
+    private final UUID id;
+    private final LocalDateTime deletedAt;
+    private final UUID deletedBy;
+
+    public static DeleteProductResDto from(DeleteProductResult result) {
+        return DeleteProductResDto.builder()
+                .id(result.getId())
+                .deletedAt(result.getDeletedAt())
+                .deletedBy(result.getDeletedBy())
+                .build();
+    }
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/presentation/dto/GetProductResDto.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/presentation/dto/GetProductResDto.java
@@ -1,0 +1,37 @@
+package com.sparta.lucky.product.presentation.dto;
+
+import com.sparta.lucky.product.application.dto.GetProductResult;
+import com.sparta.lucky.product.domain.ProductStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class GetProductResDto {
+    private final UUID id;
+    private final UUID companyId;
+    private final UUID hubId;
+    private final String name;
+    private final Integer price;
+    private final ProductStatus status;
+    private final Integer stock;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public static GetProductResDto from(GetProductResult result) {
+        return GetProductResDto.builder()
+                .id(result.getId())
+                .companyId(result.getCompanyId())
+                .hubId(result.getHubId())
+                .name(result.getName())
+                .price(result.getPrice())
+                .status(result.getStatus())
+                .stock(result.getStock())
+                .createdAt(result.getCreatedAt())
+                .updatedAt(result.getUpdatedAt())
+                .build();
+    }
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/presentation/dto/PatchProductReqDto.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/presentation/dto/PatchProductReqDto.java
@@ -1,0 +1,25 @@
+package com.sparta.lucky.product.presentation.dto;
+
+import com.sparta.lucky.product.domain.ProductStatus;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+import java.util.UUID;
+
+// 모든 필드 optional — null이면 해당 필드 미수정
+@Getter
+public class PatchProductReqDto {
+
+    @Size(max = 100, message = "상품명은 100자 이하여야 합니다.")
+    @Pattern(regexp = ".*\\S.*", message = "상품명은 공백만 입력할 수 없습니다.")
+    private String name;
+
+    private Integer price;
+
+    private ProductStatus status;
+
+    private UUID companyId;
+
+    private UUID hubId;
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/presentation/dto/PatchProductReqDto.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/presentation/dto/PatchProductReqDto.java
@@ -1,6 +1,7 @@
 package com.sparta.lucky.product.presentation.dto;
 
 import com.sparta.lucky.product.domain.ProductStatus;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -15,6 +16,8 @@ public class PatchProductReqDto {
     @Pattern(regexp = ".*\\S.*", message = "상품명은 공백만 입력할 수 없습니다.")
     private String name;
 
+    // 수정 시에도 음수 단가는 허용하지 않음 - null은 미수정을 의미하므로 허용
+    @Min(value = 0, message = "상품 단가는 0 이상이어야 합니다.")
     private Integer price;
 
     private ProductStatus status;

--- a/product-service/src/main/java/com/sparta/lucky/product/presentation/dto/PatchProductStockReqDto.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/presentation/dto/PatchProductStockReqDto.java
@@ -1,0 +1,13 @@
+package com.sparta.lucky.product.presentation.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class PatchProductStockReqDto {
+
+    @NotNull(message = "재고는 필수입니다.")
+    @Min(value = 0, message = "재고는 0 이상이어야 합니다.")
+    private Integer stock;
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/presentation/dto/PostProductReqDto.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/presentation/dto/PostProductReqDto.java
@@ -22,6 +22,7 @@ public class PostProductReqDto {
     private String name;
 
     @NotNull(message = "상품 단가는 필수 항목입니다.")
+    @Min(value = 0, message = "상품 단가는 0 이상이어야 합니다.")
     private Integer price;
 
     @NotNull(message = "재고는 필수 항목입니다.")

--- a/product-service/src/main/java/com/sparta/lucky/product/presentation/dto/PostProductReqDto.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/presentation/dto/PostProductReqDto.java
@@ -1,0 +1,30 @@
+package com.sparta.lucky.product.presentation.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class PostProductReqDto {
+
+    @NotNull(message = "소속 업체 UUID는 필수 항목입니다.")
+    private UUID companyId;
+
+    @NotNull(message = "소속 허브 UUID는 필수 항목입니다.")
+    private UUID hubId;
+
+    @NotBlank(message = "상품명은 필수 항목입니다.")
+    @Size(max = 100, message = "상품명은 100자 이하여야 합니다.")
+    private String name;
+
+    @NotNull(message = "상품 단가는 필수 항목입니다.")
+    private Integer price;
+
+    @NotNull(message = "재고는 필수 항목입니다.")
+    @Min(value = 0, message = "초기 재고는 0 이상이어야 합니다.")
+    private Integer stock;
+}

--- a/product-service/src/main/java/com/sparta/lucky/product/presentation/dto/PostProductResDto.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/presentation/dto/PostProductResDto.java
@@ -1,0 +1,39 @@
+package com.sparta.lucky.product.presentation.dto;
+
+import com.sparta.lucky.product.application.dto.CreateProductResult;
+import com.sparta.lucky.product.domain.ProductStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class PostProductResDto {
+
+    private final UUID id;
+    private final UUID companyId;
+    private final UUID hubId;
+    private final String name;
+    private final Integer price;
+    private final ProductStatus status;
+    private final Integer stock;
+    private final LocalDateTime createdAt;
+    private final UUID createdBy;
+
+    public static PostProductResDto from(CreateProductResult result) {
+        return PostProductResDto.builder()
+                .id(result.getId())
+                .companyId(result.getCompanyId())
+                .hubId(result.getHubId())
+                .name(result.getName())
+                .price(result.getPrice())
+                .status(result.getStatus())
+                .stock(result.getStock())
+                .createdAt(result.getCreatedAt())
+                .createdBy(result.getCreatedBy())
+                .build();
+    }
+
+}


### PR DESCRIPTION
## 📋 관련 이슈
- close #47

## 🔧 작업 내용

### Product 도메인 레이어
- `Product`, `ProductStock` 엔티티 구현
  - `Product` ↔ `ProductStock` `@OneToOne` 관계 (ProductStock이 연관관계 주인)
  - `ProductStock`에 `@Version` 낙관적 락 적용 (재고 동시 수정 충돌 대비)
- `ProductRepository`, `ProductStockRepository` 인터페이스 (DIP 적용)
- `ProductErrorCode`, `ProductStatus` Enum

### Infrastructure 레이어
- `ProductJpaRepository` — JOIN FETCH 쿼리로 N+1 문제 방지
- `ProductRepositoryImpl` — Domain 인터페이스 위임
- `CompanyClient`, `HubClient` FeignClient — 업체/허브 실존 검증용 내부 API 호출

### 외부 API (Presentation + Application)
| Method | URL | 권한 |
|--------|-----|------|
| POST | `/api/v1/products` | MASTER, HUB_MANAGER, COMPANY_MANAGER |
| GET | `/api/v1/products` | 전체 |
| GET | `/api/v1/products/{productId}` | 전체 |
| PATCH | `/api/v1/products/{productId}` | MASTER, HUB_MANAGER, COMPANY_MANAGER |
| DELETE | `/api/v1/products/{productId}` | MASTER, HUB_MANAGER |

### 설계 결정 사항
- `companyId`, `hubId` 변경은 MASTER만 허용 — 하위 역할의 소유권 탈취 방지
- `validateAuthority` 공용 메서드로 Create/Update/Delete 권한 검증 통합
- 권한 검증은 항상 **원래 상품의** `companyId`, `hubId` 기준으로 수행
- `HUB_MANAGER` X-Hub-Id 헤더 누락 시 Controller에서 즉시 차단 (NPE 방지)
- 상품 삭제 시 `ProductStock`도 함께 Soft Delete (생명주기 동일)

## ✅ 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [x] 불필요한 주석/코드를 제거했나요?
- [x] 로컬에서 테스트 완료했나요?
- [x] API 명세서와 일치하나요?

## 📝 리뷰 요청 사항
- 서비스 레이어 대부분이 권한 분기 관련인데, user-service 구현되면 맟춰서 수정할 예정입니다.