### PR TITLE
[feat] hub 권한 관련 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,8 @@ subprojects {
 // 2. 일반 서비스용
 configure(subprojects.findAll { it.name.endsWith("-service") }) {
     dependencies {
+        implementation 'org.springframework.boot:spring-boot-starter-security'
+        implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
         implementation 'org.springframework.boot:spring-boot-starter-web'
         implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
         runtimeOnly 'org.postgresql:postgresql'

--- a/build.gradle
+++ b/build.gradle
@@ -46,8 +46,6 @@ subprojects {
 // 2. 일반 서비스용
 configure(subprojects.findAll { it.name.endsWith("-service") }) {
     dependencies {
-        implementation 'org.springframework.boot:spring-boot-starter-security'
-        implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
         implementation 'org.springframework.boot:spring-boot-starter-web'
         implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
         runtimeOnly 'org.postgresql:postgresql'

--- a/hub-service/build.gradle
+++ b/hub-service/build.gradle
@@ -3,4 +3,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-database-postgresql'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 }

--- a/hub-service/src/main/java/com/sparta/lucky/hub/common/config/SecurityConfig.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/common/config/SecurityConfig.java
@@ -1,14 +1,17 @@
 package com.sparta.lucky.hub.common.config;
 
+import com.sparta.lucky.hub.common.filter.HeaderAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
 
     @Bean
@@ -25,8 +28,8 @@ public class SecurityConfig {
 //                        .anyRequest().authenticated()
                         // 현재는 모든 요청 permitAll
                         .anyRequest().permitAll()
-                )
-                .oauth2ResourceServer(oauth -> oauth.jwt(Customizer.withDefaults()));
+                );
+//                .addFilterBefore(new HeaderAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 }

--- a/hub-service/src/main/java/com/sparta/lucky/hub/common/config/SecurityConfig.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/common/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.sparta.lucky.hub.common.config;
 
 import com.sparta.lucky.hub.common.filter.HeaderAuthenticationFilter;
+import com.sparta.lucky.hub.common.filter.InternalRequestFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -29,6 +30,7 @@ public class SecurityConfig {
                         // 현재는 모든 요청 permitAll
                         .anyRequest().permitAll()
                 );
+//                .addFilterBefore(new InternalRequestFilter(), UsernamePasswordAuthenticationFilter.class)
 //                .addFilterBefore(new HeaderAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }

--- a/hub-service/src/main/java/com/sparta/lucky/hub/common/config/SecurityConfig.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/common/config/SecurityConfig.java
@@ -1,0 +1,32 @@
+package com.sparta.lucky.hub.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+//                        .requestMatchers(
+//                                "/swagger-ui/**",
+//                                "/swagger-ui.html",
+//                                "/v3/api-docs/**",
+//                                "/api-docs/**"
+//                        ).permitAll()
+//                        .anyRequest().authenticated()
+                        // 현재는 모든 요청 permitAll
+                        .anyRequest().permitAll()
+                )
+                .oauth2ResourceServer(oauth -> oauth.jwt(Customizer.withDefaults()));
+        return http.build();
+    }
+}

--- a/hub-service/src/main/java/com/sparta/lucky/hub/common/config/SwaggerConfig.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/common/config/SwaggerConfig.java
@@ -1,7 +1,10 @@
 package com.sparta.lucky.hub.common.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -14,6 +17,12 @@ public class SwaggerConfig {
                 .info(new Info()
                         .title("Hub Service API")
                         .description("허브 API 문서")
-                        .version("v1.0.0"));
+                        .version("v1.0.0"))
+                .addSecurityItem(new SecurityRequirement().addList("BearerAuth"))
+                .components(new Components()
+                        .addSecuritySchemes("BearerAuth", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
     }
 }

--- a/hub-service/src/main/java/com/sparta/lucky/hub/common/exception/HubErrorCode.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/common/exception/HubErrorCode.java
@@ -11,7 +11,8 @@ public enum HubErrorCode implements ErrorCode {
     HUB_ALREADY_DELETED("HUB_002", "이미 삭제된 허브입니다.", 400),
     HUB_ROUTE_INVALID_VALUE("HUB_003", "distance와 duration은 음수일 수 없습니다.", 400),
     HUB_ROUTE_NOT_FOUND("HUB_004", "두 허브 간 경로를 찾을 수 없습니다.", 404),
-    INVALID_COORDINATE("HUB_005", "대한민국 범위를 벗어난 좌표입니다. (위도 33~39, 경도 124~132)", 400);
+    INVALID_COORDINATE("HUB_005", "대한민국 범위를 벗어난 좌표입니다. (위도 33~39, 경도 124~132)", 400),
+    HUB_ACCESS_DENIED("HUB_006", "내부 서비스 요청만 허용됩니다.", 403);
 
     private final String code;
     private final String message;

--- a/hub-service/src/main/java/com/sparta/lucky/hub/common/filter/HeaderAuthenticationFilter.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/common/filter/HeaderAuthenticationFilter.java
@@ -1,0 +1,35 @@
+package com.sparta.lucky.hub.common.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+public class HeaderAuthenticationFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String userId = request.getHeader("X-User-Id");
+        String role = request.getHeader("X-User-Role");
+
+        if (userId != null && !userId.isBlank() && role != null && !role.isBlank()) {
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                    userId,
+                    null,
+                    List.of(new SimpleGrantedAuthority("ROLE_" + role))
+            );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/hub-service/src/main/java/com/sparta/lucky/hub/common/filter/InternalRequestFilter.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/common/filter/InternalRequestFilter.java
@@ -1,0 +1,34 @@
+package com.sparta.lucky.hub.common.filter;
+
+import com.sparta.lucky.hub.common.exception.BusinessException;
+import com.sparta.lucky.hub.common.exception.HubErrorCode;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class InternalRequestFilter extends OncePerRequestFilter {
+
+    private static final String INTERNAL_PATH_PREFIX = "/internal/";
+    private static final String INTERNAL_HEADER = "X-Internal-Request";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        if (request.getRequestURI().startsWith(INTERNAL_PATH_PREFIX)) {
+            validateInternalRequest(request.getHeader(INTERNAL_HEADER));
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void validateInternalRequest(String internalRequest) {
+        if (internalRequest == null || internalRequest.isBlank()) {
+            throw new BusinessException(HubErrorCode.HUB_ACCESS_DENIED);
+        }
+    }
+}

--- a/hub-service/src/main/java/com/sparta/lucky/hub/presentation/HubController.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/presentation/HubController.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
@@ -27,8 +28,8 @@ public class HubController {
 
     private final HubService hubService;
 
-    // Todo: 권한 설정
-    @Operation(summary = "허브 생성", description = "새로운 허브를 생성합니다.")
+    @Operation(summary = "허브 생성", description = "새로운 허브를 생성합니다. (MASTER 전용)")
+    @PreAuthorize("hasRole('MASTER')")
     @PostMapping
     public ResponseEntity<ApiResponse<PostHubResDto>> createHub(@Valid @RequestBody PostHubReqDto request) {
         CreateHubCommand command = CreateHubCommand.of(
@@ -52,7 +53,8 @@ public class HubController {
         return ResponseEntity.ok(ApiResponse.success(hubService.getHubsByPage(pageable).map(GetHubResDto::from)));
     }
 
-    @Operation(summary = "허브 정보 수정", description = "허브의 이름, 주소, 위경도를 수정합니다.")
+    @Operation(summary = "허브 정보 수정", description = "허브의 이름, 주소, 위경도를 수정합니다. (MASTER 전용)")
+    @PreAuthorize("hasRole('MASTER')")
     @PatchMapping("/{hubId}")
     public ResponseEntity<ApiResponse<GetHubResDto>> updateHub(
             @Parameter(description = "허브 ID") @PathVariable UUID hubId,
@@ -64,11 +66,12 @@ public class HubController {
         return ResponseEntity.ok(ApiResponse.success(GetHubResDto.from(hubService.updateHub(command))));
     }
 
-    @Operation(summary = "허브 삭제", description = "허브를 소프트 삭제합니다.")
+    @Operation(summary = "허브 삭제", description = "허브를 소프트 삭제합니다. (MASTER 전용)")
+    @PreAuthorize("hasRole('MASTER')")
     @DeleteMapping("/{hubId}")
     public ResponseEntity<ApiResponse<Void>> deleteHub(
             @Parameter(description = "허브 ID") @PathVariable UUID hubId,
-            @Parameter(description = "요청자 ID", hidden = true) @RequestHeader("X-User-Id") UUID deletedBy // Todo: 추후 수정
+            @Parameter(hidden = true) @RequestHeader("X-User-Id") UUID deletedBy
     ) {
         hubService.deleteHub(hubId, deletedBy);
         return ResponseEntity.noContent().build();

--- a/hub-service/src/main/java/com/sparta/lucky/hub/presentation/HubController.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/presentation/HubController.java
@@ -16,6 +16,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
@@ -71,9 +72,9 @@ public class HubController {
     @DeleteMapping("/{hubId}")
     public ResponseEntity<ApiResponse<Void>> deleteHub(
             @Parameter(description = "허브 ID") @PathVariable UUID hubId,
-            @Parameter(hidden = true) @RequestHeader("X-User-Id") UUID deletedBy
+            @Parameter(hidden = true) @AuthenticationPrincipal String deletedBy
     ) {
-        hubService.deleteHub(hubId, deletedBy);
+        hubService.deleteHub(hubId, UUID.fromString(deletedBy));
         return ResponseEntity.noContent().build();
     }
 }

--- a/hub-service/src/main/java/com/sparta/lucky/hub/presentation/RouteInternalController.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/presentation/RouteInternalController.java
@@ -2,19 +2,20 @@ package com.sparta.lucky.hub.presentation;
 
 import com.sparta.lucky.hub.application.RouteService;
 import com.sparta.lucky.hub.application.dto.GetRouteResult;
+import com.sparta.lucky.hub.common.response.ApiResponse;
 import com.sparta.lucky.hub.presentation.dto.GetRouteResDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.math.BigDecimal;
 import java.util.UUID;
 
 @Tag(name = "Route Internal", description = "허브 경로 내부 서비스 간 통신 API")
@@ -28,12 +29,12 @@ public class RouteInternalController {
 
     @Operation(summary = "[Internal] 허브 최단 경로 조회", description = "허브 간 최단 경로를 조회합니다.")
     @GetMapping
-    public GetRouteResDto getRoute(
+    public ResponseEntity<ApiResponse<GetRouteResDto>> getRoute(
             @Parameter(description = "출발 허브 ID") @RequestParam @NotNull UUID originHubId,
             @Parameter(description = "도착 허브 ID") @RequestParam @NotNull UUID destinationHubId
     ) {
         GetRouteResult result = routeService.getRoute(originHubId, destinationHubId);
 
-        return GetRouteResDto.from(result);
+        return ResponseEntity.ok(ApiResponse.success(GetRouteResDto.from(result)));
     }
 }

--- a/hub-service/src/main/resources/application.yaml
+++ b/hub-service/src/main/resources/application.yaml
@@ -38,6 +38,13 @@ spring:
     virtual:
       enabled: true
 
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: http://localhost:9090/realms/lucky
+          jwk-set-uri: http://lucky-keycloak:8080/realms/lucky/protocol/openid-connect/certs
+
 eureka:
   client:
     service-url:


### PR DESCRIPTION
## 📋 관련 이슈
> 관련 이슈 번호를 적어주세요.
- close #

## 🔧 작업 내용

**! 일단은 코드만 작성해두고, 현재는 permitAll로 모든 요청 권한 처리 없이 가능하도록 해두었습니다.**

### HeaderAuthenticationFilter 추가

Gateway에서 전달되는 X-User-Id, X-User-Role 헤더를 기반으로
Spring Security의 Authentication 객체를 생성하여 SecurityContext에 저장하는 필터를 추가했습니다.

Spring Security의 SecurityContext에 저장된 Authentication 객체를 저장하면,
@AuthenticationPrincipal에서 userId를 꺼내 쓸 수 있고, 
@ PreAuthorize로 권한 기반 제어가 가능합니다

```
    @Operation(summary = "허브 삭제", description = "허브를 소프트 삭제합니다. (MASTER 전용)")
    @PreAuthorize("hasRole('MASTER')")
    @DeleteMapping("/{hubId}")
    public ResponseEntity<ApiResponse<Void>> deleteHub(
            @Parameter(description = "허브 ID") @PathVariable UUID hubId,
            @Parameter(hidden = true) @AuthenticationPrincipal String deletedBy
    ) {
        hubService.deleteHub(hubId, UUID.fromString(deletedBy));
        return ResponseEntity.noContent().build();
    }
```


## ✅ 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [ ] 불필요한 주석/코드를 제거했나요?
- [ ] 로컬에서 테스트 완료했나요?
- [x] API 명세서와 일치하나요?

## 📝 리뷰 요청 사항

진영님이 말씀해주신대로 추가할 사항 추가했습니다.

다만, access token 임시로 발급하는 과정에서 의문의 문제로 토큰 발급받지 못했고 
나중에 회원가입, 로그인 API 만들어주시면 그 토큰으로
테스트는 추후에 해보겠습니다. 그래서 현재는 모든 요청 권한 확인없이 permitAll 상태입니다.

추가로, 허브 관련 권한 요구사항입니다
<img width="627" height="346" alt="스크린샷 2026-04-03 12 43 46" src="https://github.com/user-attachments/assets/1254dd10-0615-499b-8c4c-b009f0a0ace5" />

## 📷 스크린샷
> API 테스트 결과 등 첨부하면 좋아요.
> (없으면 삭제)




