### PR TITLE
feat: hub-service path caching 및 route CRUD API 구현

### DIFF
--- a/hub-service/src/main/java/com/sparta/lucky/hub/application/HubPathService.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/application/HubPathService.java
@@ -5,6 +5,7 @@ import com.sparta.lucky.hub.common.exception.BusinessException;
 import com.sparta.lucky.hub.common.exception.HubErrorCode;
 import com.sparta.lucky.hub.domain.HubRoute;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,8 +15,9 @@ import java.util.*;
 @RequiredArgsConstructor
 public class HubPathService {
 
-    private final RouteService routeService;
+    private final HubRouteService hubRouteService;
 
+    @Cacheable(cacheNames = "path", key = "#originHubId + '-' + #destinationHubId")
     @Transactional(readOnly = true)
     public GetRouteResult getRoute(UUID originHubId, UUID destinationHubId) {
 
@@ -25,7 +27,7 @@ public class HubPathService {
         }
 
         // Dijkstra로 최단 경로 탐색 (캐시 경유)
-        List<HubRoute> routes = routeService.getHubRoutes();
+        List<HubRoute> routes = hubRouteService.getHubRoutes();
         PathResult result = findShortestPath(routes, originHubId, destinationHubId);
 
         return GetRouteResult.of(originHubId, destinationHubId, result.totalDuration(), result.totalDistance(), result.path());

--- a/hub-service/src/main/java/com/sparta/lucky/hub/application/HubPathService.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/application/HubPathService.java
@@ -1,19 +1,41 @@
 package com.sparta.lucky.hub.application;
 
+import com.sparta.lucky.hub.application.dto.GetRouteResult;
 import com.sparta.lucky.hub.common.exception.BusinessException;
 import com.sparta.lucky.hub.common.exception.HubErrorCode;
 import com.sparta.lucky.hub.domain.HubRoute;
-import org.springframework.stereotype.Component;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 
-@Component
-public class HubToHubPathFinder {
+@Service
+@RequiredArgsConstructor
+public class HubPathService {
 
-    public record PathResult(List<UUID> path, int totalDistance, int totalDuration) {}
+    private final RouteService routeService;
+
+    @Transactional(readOnly = true)
+    public GetRouteResult getRoute(UUID originHubId, UUID destinationHubId) {
+
+        // 출발 허브 == 도착 허브인 경우
+        if (originHubId.equals(destinationHubId)) {
+            return GetRouteResult.of(originHubId, destinationHubId, 0, 0, List.of(originHubId));
+        }
+
+        // Dijkstra로 최단 경로 탐색 (캐시 경유)
+        List<HubRoute> routes = routeService.getHubRoutes();
+        PathResult result = findShortestPath(routes, originHubId, destinationHubId);
+
+        return GetRouteResult.of(originHubId, destinationHubId, result.totalDuration(), result.totalDistance(), result.path());
+    }
+
+
+    private record PathResult(List<UUID> path, int totalDistance, int totalDuration) {}
 
     // 시작 Hub에서 도착 Hub 최단거리 찾기
-    public PathResult findShortestPath(List<HubRoute> routes, UUID originId, UUID destinationId) {
+    private PathResult findShortestPath(List<HubRoute> routes, UUID originId, UUID destinationId) {
         // 양방향 그래프 구성: 두 허브 간 연결은 양방향으로 취급
         Map<UUID, List<HubRoute>> graph = new HashMap<>();
         for (HubRoute route : routes) {

--- a/hub-service/src/main/java/com/sparta/lucky/hub/application/HubRouteService.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/application/HubRouteService.java
@@ -1,6 +1,5 @@
 package com.sparta.lucky.hub.application;
 
-import com.sparta.lucky.hub.application.dto.GetRouteResult;
 import com.sparta.lucky.hub.common.exception.BusinessException;
 import com.sparta.lucky.hub.common.exception.HubErrorCode;
 import com.sparta.lucky.hub.domain.HubRoute;
@@ -8,6 +7,7 @@ import com.sparta.lucky.hub.infrastructure.HubRouteRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,7 +16,7 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
-public class RouteService {
+public class HubRouteService {
 
     private final HubService hubService;
     private final HubRouteRepository hubRouteRepository;
@@ -27,13 +27,19 @@ public class RouteService {
         return hubRouteRepository.findAllByDeletedAtIsNull();
     }
 
-    @CacheEvict(cacheNames = "routes", key = "'all'")
+    @Caching(evict = {
+            @CacheEvict(cacheNames = "routes", key = "'all'"),
+            @CacheEvict(cacheNames = "path", allEntries = true)
+    })
     @Transactional
     public void saveHubRoute(HubRoute hubRoute) {
         hubRouteRepository.save(hubRoute);
     }
 
-    @CacheEvict(cacheNames = "routes", key = "'all'")
+    @Caching(evict = {
+            @CacheEvict(cacheNames = "routes", key = "'all'"),
+            @CacheEvict(cacheNames = "path", allEntries = true)
+    })
     @Transactional
     public HubRoute createRoute(UUID originHubId, UUID destinationHubId, int distance, int duration) {
         hubService.getHub(originHubId);
@@ -42,7 +48,10 @@ public class RouteService {
         return hubRouteRepository.save(route);
     }
 
-    @CacheEvict(cacheNames = "routes", key = "'all'")
+    @Caching(evict = {
+            @CacheEvict(cacheNames = "routes", key = "'all'"),
+            @CacheEvict(cacheNames = "path", allEntries = true)
+    })
     @Transactional
     public HubRoute updateRoute(UUID routeId, int distance, int duration) {
         HubRoute route = findActiveRoute(routeId);
@@ -50,7 +59,10 @@ public class RouteService {
         return route;
     }
 
-    @CacheEvict(cacheNames = "routes", key = "'all'")
+    @Caching(evict = {
+            @CacheEvict(cacheNames = "routes", key = "'all'"),
+            @CacheEvict(cacheNames = "path", allEntries = true)
+    })
     @Transactional
     public void deleteRoute(UUID routeId, UUID deletedBy) {
         HubRoute route = findActiveRoute(routeId);

--- a/hub-service/src/main/java/com/sparta/lucky/hub/application/HubRouteUpdateScheduler.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/application/HubRouteUpdateScheduler.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class HubRouteUpdateScheduler {
 
-    private final RouteService routeService;
+    private final HubRouteService hubRouteService;
     private final HubService hubService;
     private final TmapRouteClient tmapRouteClient;
 
@@ -27,7 +27,7 @@ public class HubRouteUpdateScheduler {
     public void updateHubRouteInfo() {
         log.info("[HubRouteUpdateScheduler] 허브 경로 distance/duration 업데이트 시작");
 
-        List<HubRoute> routes = routeService.getHubRoutes();
+        List<HubRoute> routes = hubRouteService.getHubRoutes();
         Map<UUID, GetHubResult> hubMap = hubService.getHubs().stream()
                 .collect(Collectors.toMap(GetHubResult::getId, hub -> hub));
 
@@ -51,7 +51,7 @@ public class HubRouteUpdateScheduler {
                 );
 
                 route.updateRouteInfo(response.getTotalDistance(), response.getTotalTime());
-                routeService.saveHubRoute(route);
+                hubRouteService.saveHubRoute(route);
                 successCount++;
 
                 Thread.sleep(100);

--- a/hub-service/src/main/java/com/sparta/lucky/hub/application/HubService.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/application/HubService.java
@@ -41,6 +41,13 @@ public class HubService {
     }
 
     @Transactional(readOnly = true)
+    public GetHubResult getHubByManagerId(UUID managerId) {
+        Hub hub = hubRepository.findByManagerIdAndDeletedAtIsNull(managerId)
+                .orElseThrow(() -> new BusinessException(HubErrorCode.HUB_NOT_FOUND));
+        return GetHubResult.from(hub);
+    }
+
+    @Transactional(readOnly = true)
     public Page<GetHubResult> getHubsByPage(Pageable pageable) {
         return hubRepository.findAllByDeletedAtIsNull(pageable)
                 .map(GetHubResult::from);

--- a/hub-service/src/main/java/com/sparta/lucky/hub/application/RouteService.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/application/RouteService.java
@@ -1,6 +1,8 @@
 package com.sparta.lucky.hub.application;
 
 import com.sparta.lucky.hub.application.dto.GetRouteResult;
+import com.sparta.lucky.hub.common.exception.BusinessException;
+import com.sparta.lucky.hub.common.exception.HubErrorCode;
 import com.sparta.lucky.hub.domain.HubRoute;
 import com.sparta.lucky.hub.infrastructure.HubRouteRepository;
 import lombok.RequiredArgsConstructor;
@@ -41,5 +43,31 @@ public class RouteService {
     @Transactional
     public void saveHubRoute(HubRoute hubRoute) {
         hubRouteRepository.save(hubRoute);
+    }
+
+    @Transactional
+    public HubRoute createRoute(UUID originHubId, UUID destinationHubId, int distance, int duration) {
+        hubService.getHub(originHubId);
+        hubService.getHub(destinationHubId);
+        HubRoute route = HubRoute.create(originHubId, destinationHubId, distance, duration);
+        return hubRouteRepository.save(route);
+    }
+
+    @Transactional
+    public HubRoute updateRoute(UUID routeId, int distance, int duration) {
+        HubRoute route = findActiveRoute(routeId);
+        route.updateRouteInfo(distance, duration);
+        return route;
+    }
+
+    @Transactional
+    public void deleteRoute(UUID routeId, UUID deletedBy) {
+        HubRoute route = findActiveRoute(routeId);
+        route.softDelete(deletedBy);
+    }
+
+    private HubRoute findActiveRoute(UUID routeId) {
+        return hubRouteRepository.findByIdAndDeletedAtIsNull(routeId)
+                .orElseThrow(() -> new BusinessException(HubErrorCode.HUB_ROUTE_NOT_FOUND));
     }
 }

--- a/hub-service/src/main/java/com/sparta/lucky/hub/application/RouteService.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/application/RouteService.java
@@ -6,6 +6,8 @@ import com.sparta.lucky.hub.common.exception.HubErrorCode;
 import com.sparta.lucky.hub.domain.HubRoute;
 import com.sparta.lucky.hub.infrastructure.HubRouteRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,33 +20,20 @@ public class RouteService {
 
     private final HubService hubService;
     private final HubRouteRepository hubRouteRepository;
-    private final HubToHubPathFinder hubToHubPathFinder;
 
-    @Transactional(readOnly = true)
-    public GetRouteResult getRoute(UUID originHubId, UUID destinationHubId) {
-
-        // 출발 허브 == 도착 허브인 경우
-        if (originHubId.equals(destinationHubId)) {
-            return GetRouteResult.of(originHubId, destinationHubId, 0, 0, List.of(originHubId));
-        }
-
-        // Dijkstra로 최단 경로 탐색
-        List<HubRoute> routes = hubRouteRepository.findAllByDeletedAtIsNull();
-        HubToHubPathFinder.PathResult result = hubToHubPathFinder.findShortestPath(routes, originHubId, destinationHubId);
-
-        return GetRouteResult.of(originHubId, destinationHubId, result.totalDuration(), result.totalDistance(), result.path());
-    }
-
+    @Cacheable(cacheNames = "routes", key = "'all'")
     @Transactional(readOnly = true)
     public List<HubRoute> getHubRoutes() {
         return hubRouteRepository.findAllByDeletedAtIsNull();
     }
 
+    @CacheEvict(cacheNames = "routes", key = "'all'")
     @Transactional
     public void saveHubRoute(HubRoute hubRoute) {
         hubRouteRepository.save(hubRoute);
     }
 
+    @CacheEvict(cacheNames = "routes", key = "'all'")
     @Transactional
     public HubRoute createRoute(UUID originHubId, UUID destinationHubId, int distance, int duration) {
         hubService.getHub(originHubId);
@@ -53,6 +42,7 @@ public class RouteService {
         return hubRouteRepository.save(route);
     }
 
+    @CacheEvict(cacheNames = "routes", key = "'all'")
     @Transactional
     public HubRoute updateRoute(UUID routeId, int distance, int duration) {
         HubRoute route = findActiveRoute(routeId);
@@ -60,6 +50,7 @@ public class RouteService {
         return route;
     }
 
+    @CacheEvict(cacheNames = "routes", key = "'all'")
     @Transactional
     public void deleteRoute(UUID routeId, UUID deletedBy) {
         HubRoute route = findActiveRoute(routeId);

--- a/hub-service/src/main/java/com/sparta/lucky/hub/application/dto/GetRouteResult.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/application/dto/GetRouteResult.java
@@ -1,5 +1,7 @@
 package com.sparta.lucky.hub.application.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
 import java.util.List;
@@ -14,7 +16,14 @@ public class GetRouteResult {
     private final Integer totalDistance;
     private final List<UUID> route;
 
-    private GetRouteResult(UUID originHubId, UUID destinationHubId, Integer totalDuration, Integer totalDistance, List<UUID> route) {
+    @JsonCreator
+    private GetRouteResult(
+            @JsonProperty("originHubId") UUID originHubId,
+            @JsonProperty("destinationHubId") UUID destinationHubId,
+            @JsonProperty("totalDuration") Integer totalDuration,
+            @JsonProperty("totalDistance") Integer totalDistance,
+            @JsonProperty("route") List<UUID> route
+    ) {
         this.originHubId = originHubId;
         this.destinationHubId = destinationHubId;
         this.totalDuration = totalDuration;

--- a/hub-service/src/main/java/com/sparta/lucky/hub/common/config/CacheConfig.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/common/config/CacheConfig.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.sparta.lucky.hub.application.dto.GetHubResult;
+import com.sparta.lucky.hub.application.dto.GetRouteResult;
 import com.sparta.lucky.hub.domain.HubRoute;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -58,10 +59,19 @@ public class CacheConfig {
                         new Jackson2JsonRedisSerializer<>(objectMapper, routesType)
                 ));
 
+        // path 캐시: path 단건 (origin-destination 쌍)
+        RedisCacheConfiguration routeResultConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(30))
+                .serializeKeysWith(keySerializer)
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+                        new Jackson2JsonRedisSerializer<>(objectMapper, GetRouteResult.class)
+                ));
+
         return RedisCacheManager.builder(connectionFactory)
                 .withCacheConfiguration("hub", hubConfig)
                 .withCacheConfiguration("hubs", hubsConfig)
                 .withCacheConfiguration("routes", routesConfig)
+                .withCacheConfiguration("path", routeResultConfig)
                 .build();
     }
 }

--- a/hub-service/src/main/java/com/sparta/lucky/hub/common/config/CacheConfig.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/common/config/CacheConfig.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.sparta.lucky.hub.application.dto.GetHubResult;
+import com.sparta.lucky.hub.domain.HubRoute;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
@@ -47,9 +48,20 @@ public class CacheConfig {
                         new Jackson2JsonRedisSerializer<>(objectMapper, hubsType)
                 ));
 
+        // routes 캐시: List<HubRoute>
+        JavaType routesType = objectMapper.getTypeFactory()
+                .constructCollectionType(List.class, HubRoute.class);
+        RedisCacheConfiguration routesConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(30))
+                .serializeKeysWith(keySerializer)
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+                        new Jackson2JsonRedisSerializer<>(objectMapper, routesType)
+                ));
+
         return RedisCacheManager.builder(connectionFactory)
                 .withCacheConfiguration("hub", hubConfig)
                 .withCacheConfiguration("hubs", hubsConfig)
+                .withCacheConfiguration("routes", routesConfig)
                 .build();
     }
 }

--- a/hub-service/src/main/java/com/sparta/lucky/hub/domain/HubRoute.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/domain/HubRoute.java
@@ -35,6 +35,15 @@ public class HubRoute extends BaseEntity {
     @Column(name = "distance", nullable = false)
     private Integer distance;
 
+    public static HubRoute create(UUID originHubId, UUID destinationHubId, int distance, int duration) {
+        HubRoute route = new HubRoute();
+        route.originHubId = originHubId;
+        route.destinationHubId = destinationHubId;
+        route.distance = distance;
+        route.duration = duration;
+        return route;
+    }
+
     /** 그래프 탐색 전용 역방향 인스턴스 생성 (DB 저장 X) */
     public HubRoute reverse() {
         HubRoute reversed = new HubRoute();

--- a/hub-service/src/main/java/com/sparta/lucky/hub/infrastructure/HubRepository.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/infrastructure/HubRepository.java
@@ -13,6 +13,8 @@ public interface HubRepository extends JpaRepository<Hub, UUID> {
 
     Optional<Hub> findByIdAndDeletedAtIsNull(UUID id);
 
+    Optional<Hub> findByManagerIdAndDeletedAtIsNull(UUID managerId);
+
     Page<Hub> findAllByDeletedAtIsNull(Pageable pageable);
 
     List<Hub> findAllByDeletedAtIsNull();

--- a/hub-service/src/main/java/com/sparta/lucky/hub/infrastructure/HubRouteRepository.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/infrastructure/HubRouteRepository.java
@@ -9,4 +9,6 @@ import java.util.UUID;
 public interface HubRouteRepository extends JpaRepository<HubRoute, UUID> {
 
     List<HubRoute> findAllByDeletedAtIsNull();
+
+    java.util.Optional<HubRoute> findByIdAndDeletedAtIsNull(UUID id);
 }

--- a/hub-service/src/main/java/com/sparta/lucky/hub/presentation/HubInternalController.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/presentation/HubInternalController.java
@@ -35,6 +35,14 @@ public class HubInternalController {
         return ResponseEntity.ok(ApiResponse.success(GetHubResDto.from(hubService.getHub(hubId))));
     }
 
+    @Operation(summary = "[Internal] 매니저 ID로 허브 조회", description = "서비스 내부에서 허브 매니저 ID로 담당 허브 정보를 조회합니다.")
+    @GetMapping("/manager/{managerId}")
+    public ResponseEntity<ApiResponse<GetHubResDto>> getHubByManagerId(
+            @Parameter(description = "매니저 ID") @PathVariable UUID managerId
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(GetHubResDto.from(hubService.getHubByManagerId(managerId))));
+    }
+
     @Operation(summary = "[Internal] 허브 목록 조회", description = "서비스 내부에서 허브 목록을 페이지 단위로 조회합니다.")
     @GetMapping
     public ResponseEntity<ApiResponse<Page<GetHubResDto>>> getHubs(@ParameterObject @PageableDefault(size = 10) Pageable pageable) {

--- a/hub-service/src/main/java/com/sparta/lucky/hub/presentation/PathInternalController.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/presentation/PathInternalController.java
@@ -21,7 +21,7 @@ import java.util.UUID;
 @Tag(name = "Path Internal", description = "허브 경로 내부 서비스 간 통신 API")
 @Validated
 @RestController
-@RequestMapping("/internal/api/v1/routes")
+@RequestMapping("/internal/api/v1/paths")
 @RequiredArgsConstructor
 public class PathInternalController {
 

--- a/hub-service/src/main/java/com/sparta/lucky/hub/presentation/PathInternalController.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/presentation/PathInternalController.java
@@ -18,12 +18,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
 
-@Tag(name = "Route Internal", description = "허브 경로 내부 서비스 간 통신 API")
+@Tag(name = "Path Internal", description = "허브 경로 내부 서비스 간 통신 API")
 @Validated
 @RestController
 @RequestMapping("/internal/api/v1/routes")
 @RequiredArgsConstructor
-public class RouteInternalController {
+public class PathInternalController {
 
     private final HubPathService hubPathService;
 

--- a/hub-service/src/main/java/com/sparta/lucky/hub/presentation/RouteController.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/presentation/RouteController.java
@@ -1,0 +1,69 @@
+package com.sparta.lucky.hub.presentation;
+
+import com.sparta.lucky.hub.application.RouteService;
+import com.sparta.lucky.hub.common.response.ApiResponse;
+import com.sparta.lucky.hub.presentation.dto.PatchRouteReqDto;
+import com.sparta.lucky.hub.presentation.dto.PostRouteReqDto;
+import com.sparta.lucky.hub.presentation.dto.RouteResDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@Tag(name = "Route", description = "허브 경로 관리 API")
+@RestController
+@RequestMapping("/api/v1/routes")
+@RequiredArgsConstructor
+public class RouteController {
+
+    private final RouteService routeService;
+
+    @Operation(summary = "허브 경로 생성", description = "두 허브 간 경로를 생성합니다. (MASTER 전용)")
+    @PreAuthorize("hasRole('MASTER')")
+    @PostMapping
+    public ResponseEntity<ApiResponse<RouteResDto>> createRoute(
+            @Valid @RequestBody PostRouteReqDto request
+    ) {
+        RouteResDto response = RouteResDto.from(
+                routeService.createRoute(
+                        request.getOriginHubId(),
+                        request.getDestinationHubId(),
+                        request.getDistance(),
+                        request.getDuration()
+                )
+        );
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "허브 경로 수정", description = "경로의 거리 및 소요 시간을 수정합니다. (MASTER 전용)")
+    @PreAuthorize("hasRole('MASTER')")
+    @PatchMapping("/{routeId}")
+    public ResponseEntity<ApiResponse<RouteResDto>> updateRoute(
+            @Parameter(description = "경로 ID") @PathVariable UUID routeId,
+            @Valid @RequestBody PatchRouteReqDto request
+    ) {
+        RouteResDto response = RouteResDto.from(
+                routeService.updateRoute(routeId, request.getDistance(), request.getDuration())
+        );
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "허브 경로 삭제", description = "경로를 소프트 삭제합니다. (MASTER 전용)")
+    @PreAuthorize("hasRole('MASTER')")
+    @DeleteMapping("/{routeId}")
+    public ResponseEntity<ApiResponse<Void>> deleteRoute(
+            @Parameter(description = "경로 ID") @PathVariable UUID routeId,
+            @Parameter(hidden = true) @AuthenticationPrincipal String deletedBy
+    ) {
+        routeService.deleteRoute(routeId, UUID.fromString(deletedBy));
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/hub-service/src/main/java/com/sparta/lucky/hub/presentation/RouteController.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/presentation/RouteController.java
@@ -1,6 +1,6 @@
 package com.sparta.lucky.hub.presentation;
 
-import com.sparta.lucky.hub.application.RouteService;
+import com.sparta.lucky.hub.application.HubRouteService;
 import com.sparta.lucky.hub.common.response.ApiResponse;
 import com.sparta.lucky.hub.presentation.dto.PatchRouteReqDto;
 import com.sparta.lucky.hub.presentation.dto.PostRouteReqDto;
@@ -16,6 +16,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @Tag(name = "Route", description = "허브 경로 관리 API")
@@ -24,7 +25,16 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class RouteController {
 
-    private final RouteService routeService;
+    private final HubRouteService hubRouteService;
+
+    @Operation(summary = "허브 경로 전체 조회", description = "삭제되지 않은 모든 허브 경로를 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<RouteResDto>>> getRoutes() {
+        List<RouteResDto> response = hubRouteService.getHubRoutes().stream()
+                .map(RouteResDto::from)
+                .toList();
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
 
     @Operation(summary = "허브 경로 생성", description = "두 허브 간 경로를 생성합니다. (MASTER 전용)")
     @PreAuthorize("hasRole('MASTER')")
@@ -33,7 +43,7 @@ public class RouteController {
             @Valid @RequestBody PostRouteReqDto request
     ) {
         RouteResDto response = RouteResDto.from(
-                routeService.createRoute(
+                hubRouteService.createRoute(
                         request.getOriginHubId(),
                         request.getDestinationHubId(),
                         request.getDistance(),
@@ -51,7 +61,7 @@ public class RouteController {
             @Valid @RequestBody PatchRouteReqDto request
     ) {
         RouteResDto response = RouteResDto.from(
-                routeService.updateRoute(routeId, request.getDistance(), request.getDuration())
+                hubRouteService.updateRoute(routeId, request.getDistance(), request.getDuration())
         );
         return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -63,7 +73,7 @@ public class RouteController {
             @Parameter(description = "경로 ID") @PathVariable UUID routeId,
             @Parameter(hidden = true) @AuthenticationPrincipal String deletedBy
     ) {
-        routeService.deleteRoute(routeId, UUID.fromString(deletedBy));
+        hubRouteService.deleteRoute(routeId, UUID.fromString(deletedBy));
         return ResponseEntity.noContent().build();
     }
 }

--- a/hub-service/src/main/java/com/sparta/lucky/hub/presentation/RouteInternalController.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/presentation/RouteInternalController.java
@@ -1,6 +1,6 @@
 package com.sparta.lucky.hub.presentation;
 
-import com.sparta.lucky.hub.application.RouteService;
+import com.sparta.lucky.hub.application.HubPathService;
 import com.sparta.lucky.hub.application.dto.GetRouteResult;
 import com.sparta.lucky.hub.common.response.ApiResponse;
 import com.sparta.lucky.hub.presentation.dto.GetRouteResDto;
@@ -25,7 +25,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class RouteInternalController {
 
-    private final RouteService routeService;
+    private final HubPathService hubPathService;
 
     @Operation(summary = "[Internal] 허브 최단 경로 조회", description = "허브 간 최단 경로를 조회합니다.")
     @GetMapping
@@ -33,7 +33,7 @@ public class RouteInternalController {
             @Parameter(description = "출발 허브 ID") @RequestParam @NotNull UUID originHubId,
             @Parameter(description = "도착 허브 ID") @RequestParam @NotNull UUID destinationHubId
     ) {
-        GetRouteResult result = routeService.getRoute(originHubId, destinationHubId);
+        GetRouteResult result = hubPathService.getRoute(originHubId, destinationHubId);
 
         return ResponseEntity.ok(ApiResponse.success(GetRouteResDto.from(result)));
     }

--- a/hub-service/src/main/java/com/sparta/lucky/hub/presentation/dto/PatchRouteReqDto.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/presentation/dto/PatchRouteReqDto.java
@@ -1,0 +1,17 @@
+package com.sparta.lucky.hub.presentation.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class PatchRouteReqDto {
+
+    @NotNull
+    @Min(0)
+    private Integer distance;
+
+    @NotNull
+    @Min(0)
+    private Integer duration;
+}

--- a/hub-service/src/main/java/com/sparta/lucky/hub/presentation/dto/PostRouteReqDto.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/presentation/dto/PostRouteReqDto.java
@@ -1,0 +1,25 @@
+package com.sparta.lucky.hub.presentation.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class PostRouteReqDto {
+
+    @NotNull
+    private UUID originHubId;
+
+    @NotNull
+    private UUID destinationHubId;
+
+    @NotNull
+    @Min(0)
+    private Integer distance;
+
+    @NotNull
+    @Min(0)
+    private Integer duration;
+}

--- a/hub-service/src/main/java/com/sparta/lucky/hub/presentation/dto/RouteResDto.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/presentation/dto/RouteResDto.java
@@ -1,0 +1,28 @@
+package com.sparta.lucky.hub.presentation.dto;
+
+import com.sparta.lucky.hub.domain.HubRoute;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class RouteResDto {
+
+    private final UUID id;
+    private final UUID originHubId;
+    private final UUID destinationHubId;
+    private final Integer distance;
+    private final Integer duration;
+
+    private RouteResDto(HubRoute route) {
+        this.id = route.getId();
+        this.originHubId = route.getOriginHubId();
+        this.destinationHubId = route.getDestinationHubId();
+        this.distance = route.getDistance();
+        this.duration = route.getDuration();
+    }
+
+    public static RouteResDto from(HubRoute route) {
+        return new RouteResDto(route);
+    }
+}


### PR DESCRIPTION
## 📋 관련 이슈        
  - close #70
                                                                
  ## 🔧 작업 내용
                                                                
  ### 1. Route, Path 용어 정리     
     
```                                                     
Hub: 허브
Route: Hub 간 단일 조합 ex) 대전-대구
Path: 여러 Route 조합 ex) 대전-대구-부산
```
                                   
  - `RouteService` → `HubRouteService`(경로 CRUD + 캐시 관리), `HubPathService`(최단경로 탐색)로 분리                        
  - `RouteInternalController` → `PathInternalController`로 이름 변경


이에 따라 최단 path 조회 API url을
`/internal/api/v1/routes?originHubId={originHubId}&destinationHubId={destinationHubId}` 에서
`/internal/api/v1/paths?originHubId={originHubId}&destinationHubId={destinationHubId}` 로 수정하겠습니다.   
<img width="506" height="704" alt="image" src="https://github.com/user-attachments/assets/f64e012c-5ac2-476b-aaf7-eb80a8073a01" />

  ### 2. Route CRUD API 추가 (MASTER 전용)                          
                                                                            
  ### 3. Redis 캐싱 적용
  - `routes::all`
  - `path::{originId}-{destinationId}`
                                                                
  ## ✅ 체크리스트 
  - [x] 코드 컨벤션을 지켰나요?                                 
  - [ ] 불필요한 주석/코드를 제거했나요?                        
  - [x] 로컬에서 테스트 완료했나요?
  - [x] API 명세서와 일치하나요?                                
                                                                