### PR TITLE
feat / company-service feign 연동 완성 + product 보안설정 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ replay_pid*
 # 예외! example은 올려야 함
 
 application-local.yml
+application-local.yaml
 application-secret.yml
 
 # IntelliJ
@@ -45,3 +46,7 @@ build/
 
 # 테스트 설정
 **/src/test/resources/application.properties
+
+# IntelliJ HTTP Client 환경변수 (로컬 전용)
+http-client.env.json
+http-client.private.env.json

--- a/company-service/build.gradle
+++ b/company-service/build.gradle
@@ -1,6 +1,13 @@
 bootJar {
 	archiveFileName = 'company-service.jar'
 }
+
+dependencies {
+	// Gateway JWT 인증 연동 — Gateway가 검증한 토큰을 각 서비스에서도 검증
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+}
+
 // Java 21 + Mockito 조합에서 Mockito가 동적으로 agent를 로드하는 방식이
 // 추후 JDK에서 막힐거라는 경고문 발생 (테스트시)
 // 해당 부분 추가로 방지

--- a/company-service/src/main/java/com/sparta/lucky/company/application/CompanyService.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/application/CompanyService.java
@@ -6,6 +6,10 @@ import com.sparta.lucky.company.domain.Company;
 import com.sparta.lucky.company.domain.CompanyErrorCode;
 import com.sparta.lucky.company.domain.CompanyRepository;
 import com.sparta.lucky.company.domain.CompanyType;
+import com.sparta.lucky.company.infrastructure.feign.HubClient;
+import com.sparta.lucky.company.infrastructure.feign.ProductInternalClient;
+import com.sparta.lucky.company.infrastructure.feign.dto.BulkDeleteResponse;
+import com.sparta.lucky.company.infrastructure.feign.dto.FeignApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -32,8 +36,8 @@ public class CompanyService {
     private static final String ROLE_COMPANY_MANAGER = "COMPANY_MANAGER";
 
     private final CompanyRepository companyRepository;
-    // TODO: HubClient hubClient — hub 존재 여부 검증 (hub-service 구현 후 추가)
-    // TODO: ProductInternalClient productClient — 업체 삭제 시 상품 일괄 삭제
+    private final HubClient hubClient;
+    private final ProductInternalClient productInternalClient;
 
     @Transactional
     public CreateCompanyResult createCompany(CreateCompanyCommand command) {
@@ -57,7 +61,7 @@ public class CompanyService {
             }
         }
 
-        // TODO: hubClient.getHub(command.getHubId()) — 허브 실존 여부 검증
+        validateHub(command.getHubId());
 
         Company company = Company.builder()
                 .name(command.getName())
@@ -111,7 +115,7 @@ public class CompanyService {
                         command.getRequesterId(), command.getRequesterRole());
                 throw new BusinessException(CompanyErrorCode.COMPANY_ACCESS_DENIED);
             }
-            // TODO: 변경할 hub 존재 여부 검증
+            validateHub(command.getHubId());
             company.changeHub(command.getHubId());
         }
 
@@ -149,8 +153,7 @@ public class CompanyService {
         company.softDelete(requesterId);
         log.info("업체 삭제 완료 - companyId: {}, deletedBy: {}", companyId, requesterId);
 
-        // TODO: productClient.deleteByCompanyId(companyId) — 하위 product 일괄 soft delete
-        // 실패 시 부분 삭제 상태 발생 가능
+        deleteProductsByCompany(companyId, requesterId);
 
         return DeleteCompanyResult.of(company.getDeletedAt(), company.getDeletedBy());
     }
@@ -203,6 +206,44 @@ public class CompanyService {
                         command.getRequesterId(), command.getRequesterRole());
                 throw new BusinessException(CompanyErrorCode.COMPANY_ACCESS_DENIED);
             }
+        }
+    }
+
+    /**
+     * hub-service 내부 API로 허브 실존 여부 검증
+     * FeignException.NotFound → HUB_NOT_FOUND 변환
+     */
+    private void validateHub(UUID hubId) {
+        log.info("[Feign] hub-service 허브 검증 요청 - hubId: {}", hubId);
+        try {
+            hubClient.getHub(hubId, "true")
+                    .requireData(() -> new BusinessException(CompanyErrorCode.HUB_NOT_FOUND));
+            log.info("[Feign] hub-service 허브 검증 성공 - hubId: {}", hubId);
+        } catch (feign.FeignException.NotFound e) {
+            log.warn("[Feign] hub-service 허브 없음 - hubId: {}", hubId);
+            throw new BusinessException(CompanyErrorCode.HUB_NOT_FOUND);
+        } catch (feign.FeignException e) {
+            log.error("[Feign] hub-service 호출 실패 - hubId: {}, status: {}, message: {}",
+                    hubId, e.status(), e.getMessage());
+            throw new BusinessException(CompanyErrorCode.HUB_NOT_FOUND);
+        }
+    }
+
+    /**
+     * product-service 내부 API로 소속 상품 일괄 soft delete
+     * 실패해도 업체 삭제는 완료된 상태 — Known Limitation (분산 트랜잭션 없음)
+     */
+    private void deleteProductsByCompany(UUID companyId, UUID deletedBy) {
+        log.info("[Feign] product-service 상품 일괄 삭제 요청 - companyId: {}", companyId);
+        try {
+            FeignApiResponse<BulkDeleteResponse> response =
+                    productInternalClient.deleteProductsByCompany(companyId, "true", deletedBy);
+            log.info("[Feign] product-service 상품 일괄 삭제 완료 - companyId: {}, deletedCount: {}",
+                    companyId, response.getData() != null ? response.getData().getDeletedCount() : 0);
+        } catch (feign.FeignException e) {
+            // 실패해도 업체 삭제는 이미 커밋됨 — 부분 삭제 상태 발생 가능 (Known Limitation)
+            log.error("[Feign] product-service 상품 일괄 삭제 실패 - companyId: {}, status: {}, message: {}",
+                    companyId, e.status(), e.getMessage());
         }
     }
 }

--- a/company-service/src/main/java/com/sparta/lucky/company/application/CompanyService.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/application/CompanyService.java
@@ -220,12 +220,15 @@ public class CompanyService {
                     .requireData(() -> new BusinessException(CompanyErrorCode.HUB_NOT_FOUND));
             log.info("[Feign] hub-service 허브 검증 성공 - hubId: {}", hubId);
         } catch (feign.FeignException.NotFound e) {
+            // 404 — 실제로 허브가 없는 경우
             log.warn("[Feign] hub-service 허브 없음 - hubId: {}", hubId);
             throw new BusinessException(CompanyErrorCode.HUB_NOT_FOUND);
         } catch (feign.FeignException e) {
+            // 5xx, 타임아웃 등 - "허브 없음"이 아니라 hub-service 장애
+            // 원본 예외를 그대로 재발생시켜 장애 원인이 숨겨지지 않도록 함
             log.error("[Feign] hub-service 호출 실패 - hubId: {}, status: {}, message: {}",
                     hubId, e.status(), e.getMessage());
-            throw new BusinessException(CompanyErrorCode.HUB_NOT_FOUND);
+            throw e;
         }
     }
 

--- a/company-service/src/main/java/com/sparta/lucky/company/common/config/SecurityConfig.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/common/config/SecurityConfig.java
@@ -1,0 +1,29 @@
+package com.sparta.lucky.company.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        // 내부 API — 서비스 간 직접 호출, JWT 없음. 컨트롤러에서 X-Internal-Request 헤더로 검증
+                        .requestMatchers("/internal/api/v1/**").permitAll()
+                        // Swagger UI
+                        .requestMatchers("/swagger-ui/**", "/api-docs/**").permitAll()
+                        // 외부 API — Gateway가 JWT 검증 후 X-User-Id, X-User-Role 헤더 주입
+                        .anyRequest().authenticated()
+                )
+                .oauth2ResourceServer(oauth -> oauth.jwt(Customizer.withDefaults()));
+        return http.build();
+    }
+}

--- a/company-service/src/main/java/com/sparta/lucky/company/domain/Company.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/domain/Company.java
@@ -3,6 +3,8 @@ package com.sparta.lucky.company.domain;
 import com.sparta.lucky.company.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.UuidGenerator;
+
 import java.util.Objects;
 
 import java.util.UUID;
@@ -16,8 +18,9 @@ import java.util.UUID;
 public class Company extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(columnDefinition = "uuid")
+    @GeneratedValue
+    @UuidGenerator
+    @Column(updatable = false, nullable = false)
     private UUID id;
 
     @Column(name = "name", length = 100, nullable = false)

--- a/company-service/src/main/java/com/sparta/lucky/company/domain/CompanyErrorCode.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/domain/CompanyErrorCode.java
@@ -11,7 +11,8 @@ public enum CompanyErrorCode implements ErrorCode {
     COMPANY_NOT_FOUND("COMPANY_001", "업체를 찾을 수 없습니다.", 404),
     COMPANY_ACCESS_DENIED("COMPANY_002", "해당 업체에 접근 권한이 없습니다.", 403),
     COMPANY_HUB_MISMATCH("COMPANY_003", "허브 관리자는 소속 허브의 업체만 관리할 수 있습니다.", 403),
-    COMPANY_ALREADY_DELETED("COMPANY_004", "이미 삭제된 업체입니다.", 409);
+    COMPANY_ALREADY_DELETED("COMPANY_004", "이미 삭제된 업체입니다.", 409),
+    HUB_NOT_FOUND("COMPANY_005", "허브를 찾을 수 없습니다.", 404);
 
     private final String code;
     private final String message;

--- a/company-service/src/main/java/com/sparta/lucky/company/domain/CompanyType.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/domain/CompanyType.java
@@ -1,6 +1,6 @@
 package com.sparta.lucky.company.domain;
 
 public enum CompanyType {
-    SUPPLIER,  // 생산업체 — 물건을 보내는 쪽 (requester_company)
-    RECEIVER   // 수령업체 — 물건을 받는 쪽 (receiver_company)
+    SUPPLIER,
+    RECEIVER
 }

--- a/company-service/src/main/java/com/sparta/lucky/company/infrastructure/feign/HubClient.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/infrastructure/feign/HubClient.java
@@ -1,0 +1,21 @@
+package com.sparta.lucky.company.infrastructure.feign;
+
+import com.sparta.lucky.company.infrastructure.feign.dto.FeignApiResponse;
+import com.sparta.lucky.company.infrastructure.feign.dto.HubResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import java.util.UUID;
+
+// Eureka 서비스명으로 로드밸런싱
+@FeignClient(name = "hub-service")
+public interface HubClient {
+
+    @GetMapping("/internal/api/v1/hubs/{hubId}")
+    FeignApiResponse<HubResponse> getHub(
+            @PathVariable("hubId") UUID hubId,
+            @RequestHeader("X-Internal-Request") String internalRequest
+    );
+}

--- a/company-service/src/main/java/com/sparta/lucky/company/infrastructure/feign/ProductInternalClient.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/infrastructure/feign/ProductInternalClient.java
@@ -1,0 +1,22 @@
+package com.sparta.lucky.company.infrastructure.feign;
+
+import com.sparta.lucky.company.infrastructure.feign.dto.BulkDeleteResponse;
+import com.sparta.lucky.company.infrastructure.feign.dto.FeignApiResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import java.util.UUID;
+
+// product-service 내부 API - 업체 삭제 시 하위 상품 일괄 soft delete
+@FeignClient(name = "product-service")
+public interface ProductInternalClient {
+
+    @DeleteMapping("/internal/api/v1/products/company/{companyId}")
+    FeignApiResponse<BulkDeleteResponse> deleteProductsByCompany(
+            @PathVariable("companyId") UUID companyId,
+            @RequestHeader("X-Internal-Request") String internalRequest,
+            @RequestHeader("X-User-Id") UUID deletedBy // Audit 주체
+    );
+}

--- a/company-service/src/main/java/com/sparta/lucky/company/infrastructure/feign/dto/BulkDeleteResponse.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/infrastructure/feign/dto/BulkDeleteResponse.java
@@ -1,0 +1,16 @@
+package com.sparta.lucky.company.infrastructure.feign.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+// product-service 일괄 삭제 응답 — 로깅용
+@Getter
+@NoArgsConstructor
+public class BulkDeleteResponse {
+    private UUID companyId;
+    private int deletedCount;
+    private LocalDateTime deletedAt;
+}

--- a/company-service/src/main/java/com/sparta/lucky/company/infrastructure/feign/dto/FeignApiResponse.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/infrastructure/feign/dto/FeignApiResponse.java
@@ -1,0 +1,22 @@
+package com.sparta.lucky.company.infrastructure.feign.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.function.Supplier;
+
+// { "success": true, "data": {...} } 형태 응답 역직렬화 래퍼
+@Getter
+@NoArgsConstructor
+public class FeignApiResponse<T> {
+    private boolean success;
+    private T data;
+
+    // success=false 이거나 data=null인 경우 지정한 예외를 던지는 안전 접근 메서드
+    public T requireData(Supplier<? extends RuntimeException> exceptionSupplier) {
+        if (!success || data == null) {
+            throw exceptionSupplier.get();
+        }
+        return data;
+    }
+}

--- a/company-service/src/main/java/com/sparta/lucky/company/infrastructure/feign/dto/HubResponse.java
+++ b/company-service/src/main/java/com/sparta/lucky/company/infrastructure/feign/dto/HubResponse.java
@@ -1,0 +1,14 @@
+package com.sparta.lucky.company.infrastructure.feign.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+// hub-service 내부 API 응답 - 허브 실존 검증에 필요한 필드만 받아옴
+@Getter
+@NoArgsConstructor
+public class HubResponse {
+    private UUID hubId;
+    private String name;
+}

--- a/company-service/src/main/resources/application.yaml
+++ b/company-service/src/main/resources/application.yaml
@@ -20,6 +20,12 @@ spring:
   threads:
    virtual:
     enabled: true
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${KEYCLOAK_ISSUER_URI:http://lucky-keycloak:8080/realms/lucky}
+          jwk-set-uri: ${KEYCLOAK_JWK_SET_URI:http://lucky-keycloak:8080/realms/lucky/protocol/openid-connect/certs}
 
 eureka:
   client:
@@ -27,6 +33,7 @@ eureka:
       defaultZone: http://lucky-eureka:19090/eureka
   instance:
     prefer-ip-address: true
+
 
 management:
   tracing:

--- a/product-service/build.gradle
+++ b/product-service/build.gradle
@@ -1,6 +1,13 @@
 bootJar {
 	archiveFileName = 'product-service.jar'
 }
+
+dependencies {
+	// Gateway JWT 인증 연동 — Gateway가 검증한 토큰을 각 서비스에서도 검증
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+}
+
 // Java 21 + Mockito 조합에서 Mockito가 동적으로 agent를 로드하는 방식이
 // 추후 JDK에서 막힐거라는 경고문 발생 (테스트시)
 // 해당 부분 추가로 방지

--- a/product-service/src/main/java/com/sparta/lucky/product/common/config/SecurityConfig.java
+++ b/product-service/src/main/java/com/sparta/lucky/product/common/config/SecurityConfig.java
@@ -1,0 +1,29 @@
+package com.sparta.lucky.product.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        // 내부 API — 서비스 간 직접 호출, JWT 없음. 컨트롤러에서 X-Internal-Request 헤더로 검증
+                        .requestMatchers("/internal/api/v1/**").permitAll()
+                        // Swagger UI
+                        .requestMatchers("/swagger-ui/**", "/api-docs/**").permitAll()
+                        // 외부 API — Gateway가 JWT 검증 후 X-User-Id, X-User-Role 헤더 주입
+                        .anyRequest().authenticated()
+                )
+                .oauth2ResourceServer(oauth -> oauth.jwt(Customizer.withDefaults()));
+        return http.build();
+    }
+}

--- a/product-service/src/main/resources/application.yaml
+++ b/product-service/src/main/resources/application.yaml
@@ -21,6 +21,14 @@ spring:
     virtual:
       enabled: true
 
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          # Docker 네트워크 내부에서 Keycloak 접근
+          issuer-uri: http://lucky-keycloak:8080/realms/lucky
+          jwk-set-uri: http://lucky-keycloak:8080/realms/lucky/protocol/openid-connect/certs
+
 eureka:
   client:
     service-url:

--- a/product-service/src/main/resources/application.yaml
+++ b/product-service/src/main/resources/application.yaml
@@ -20,14 +20,12 @@ spring:
   threads:
     virtual:
       enabled: true
-
   security:
     oauth2:
       resourceserver:
         jwt:
-          # Docker 네트워크 내부에서 Keycloak 접근
-          issuer-uri: http://lucky-keycloak:8080/realms/lucky
-          jwk-set-uri: http://lucky-keycloak:8080/realms/lucky/protocol/openid-connect/certs
+          issuer-uri: ${KEYCLOAK_ISSUER_URI:http://lucky-keycloak:8080/realms/lucky}
+          jwk-set-uri: ${KEYCLOAK_JWK_SET_URI:http://lucky-keycloak:8080/realms/lucky/protocol/openid-connect/certs}
 
 eureka:
   client:


### PR DESCRIPTION
## 📋 관련 이슈
> 관련 이슈 번호를 적어주세요.
- close #74 

## 🔧 작업 내용

- build.gradle에 Spring Security + OAuth2 의존성 추가
- Hub 실존 검증용 Feign client 작성
- Company 삭제시 호출 > 관련 product / productStock 일괄 삭제 Feign client 작성
- 내부 API용 dto파일 작성
- 허브 실존 검증 응답 바탕으로 검증 로직 서비스에 추가
- 관련 에러코드 추가
- product-service keycloak 관련 보안설정 추가
- gitignore 업데이트

## ✅ 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [x] 불필요한 주석/코드를 제거했나요?
- [x] 로컬에서 테스트 완료했나요?
- [x] API 명세서와 일치하나요?

## 📝 리뷰 요청 사항
> 리뷰어가 집중해서 봐줬으면 하는 부분을 적어주세요.

- infrastructure/feign 패키지 위치, 파일명 설정 주말에 팀원분들과 상의해서 통일하겠습니다.
- 남은작업은 테스트코드작성 / swagger 문서작업입니다.

