### PR TITLE
 [feat] order-service FeignClient 연동 구현

### DIFF
--- a/order-service/http-requests/test2.http
+++ b/order-service/http-requests/test2.http
@@ -1,0 +1,52 @@
+### 1. 주문 목록 조회 (MASTER - 전체)
+GET http://localhost:19500/api/v1/orders
+X-User-Id: 00000000-0000-0000-0000-000000000001
+X-User-Role: MASTER
+
+### 2. 주문 목록 조회 (MASTER - status 필터)
+GET http://localhost:19500/api/v1/orders?status=CREATED
+X-User-Id: 00000000-0000-0000-0000-000000000001
+X-User-Role: MASTER
+
+### 3. 주문 단건 조회
+GET http://localhost:19500/api/v1/orders/11111111-1111-1111-1111-111111111111
+X-User-Id: 00000000-0000-0000-0000-000000000001
+X-User-Role: MASTER
+
+### 4. 주문 수정
+PATCH http://localhost:19500/api/v1/orders/11111111-1111-1111-1111-111111111111
+Content-Type: application/json
+X-User-Id: 00000000-0000-0000-0000-000000000001
+X-User-Role: MASTER
+
+{
+  "requestNote": "수정된 요청사항입니다",
+  "requestedDeadline": "2026-04-20T15:00:00"
+}
+
+### 5. 주문 취소 (delivery 서비스 없어서 에러날 수 있음->에러남)
+PATCH http://localhost:19500/api/v1/orders/11111111-1111-1111-1111-111111111111/cancel
+X-User-Id: 00000000-0000-0000-0000-000000000001
+X-User-Role: MASTER
+
+### 6. 주문 삭제 (취소 후에 해야 함 - CANCELLED 상태만 가능->기존에 만들어두었던 취소데이터사용해서 확인 완료)
+DELETE http://localhost:19500/api/v1/orders/3e9b901c-236f-4f87-b0a5-ce87dc1d077e
+X-User-Id: 00000000-0000-0000-0000-000000000001
+X-User-Role: MASTER
+
+### 7. 내부 API - 주문 조회 (헤더 있음 - 200 떠야 함)
+GET http://localhost:19500/internal/api/v1/orders/11111111-1111-1111-1111-111111111111
+X-Internal-Request: true
+
+### 8. 내부 API - 헤더 없음 (403 떠야 함)
+GET http://localhost:19500/internal/api/v1/orders/11111111-1111-1111-1111-111111111111
+
+### 9. 없는 주문 조회 (404 떠야 함)
+GET http://localhost:19500/api/v1/orders/99999999-9999-9999-9999-999999999999
+X-User-Id: 00000000-0000-0000-0000-000000000001
+X-User-Role: MASTER
+
+### 10. 권한 없는 역할 목록 조회 (403 떠야 함)
+GET http://localhost:19500/api/v1/orders
+X-User-Id: 00000000-0000-0000-0000-000000000001
+X-User-Role: DELIVERY_DRIVER

--- a/order-service/src/main/java/com/sparta/lucky/order/application/OrderService.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/application/OrderService.java
@@ -133,8 +133,7 @@ public class OrderService {
                             request.getReceiverCompanyId(),
                             product.getHubId(),
                             recipient != null ? recipient.getName() : "미확인",
-                            recipient != null ? recipient.getReceiverSlackId() : "",
-                            request.getRequestedDeadline()
+                            recipient != null ? recipient.getReceiverSlackId() : ""
                     ), INTERNAL_REQUEST)
                     .getData();
         } catch (RuntimeException ex) {
@@ -259,7 +258,7 @@ public class OrderService {
         DeliveryStatusResponse status = deliveryClient
                 .getDeliveryStatus(id, INTERNAL_REQUEST)
                 .getData();
-        if (status != null && !"WAITING".equals(status.getDeliveryStatus())) {
+        if (status == null || !"WAITING".equals(status.getDeliveryStatus())) {
             throw new BusinessException(OrderErrorCode.INVALID_ORDER_STATUS);
         }
 
@@ -270,8 +269,8 @@ public class OrderService {
                 INTERNAL_REQUEST
         );
 
-        // TODO: 4. 배송 취소 API 구현되면 추가
-        // // deliveryClient.cancelDelivery(order.getDeliveryId(), INTERNAL_REQUEST);
+        // 4. 배송 취소
+        deliveryClient.cancelDelivery(order.getDeliveryId(), INTERNAL_REQUEST);
         order.cancel();
         return OrderResponse.from(order);
     }

--- a/order-service/src/main/java/com/sparta/lucky/order/application/OrderService.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/application/OrderService.java
@@ -126,16 +126,28 @@ public class OrderService {
         }
 
         // 7. 배송 생성 → deliveryId 확보
-        DeliveryCreateResponse delivery = deliveryClient
-                .createDelivery(new DeliveryCreateRequest(
-                        order.getId(),
-                        request.getReceiverCompanyId(),
-                        product.getHubId(),
-                        recipient != null ? recipient.getName() : "미확인",
-                        recipient != null ? recipient.getReceiverSlackId() : "",
-                        request.getRequestedDeadline()
-                ), INTERNAL_REQUEST)
-                .getData();
+        DeliveryCreateResponse delivery;
+        try {
+            delivery = deliveryClient
+                    .createDelivery(new DeliveryCreateRequest(
+                            order.getId(),
+                            request.getReceiverCompanyId(),
+                            product.getHubId(),
+                            recipient != null ? recipient.getName() : "미확인",
+                            recipient != null ? recipient.getReceiverSlackId() : "",
+                            request.getRequestedDeadline()
+                    ), INTERNAL_REQUEST)
+                    .getData();
+        } catch (RuntimeException ex) {
+            // 보상 트랜잭션: 배송 생성 실패 시 재고 복원
+            log.error("배송 생성 실패 - 재고 복원 시작", ex);
+            productClient.restoreStock(
+                    request.getProductId(),
+                    new StockUpdateRequest(request.getQuantity()),
+                    INTERNAL_REQUEST
+            );
+            throw new BusinessException(OrderErrorCode.DELIVERY_CREATE_FAILED);
+        }
         if (delivery == null || delivery.getDeliveryId() == null) {
             // 보상 트랜잭션: 재고 복원
             productClient.restoreStock(
@@ -199,6 +211,7 @@ public class OrderService {
                     .map(OrderResponse::from);
         } //else if ("DELIVERY_DRIVER".equals(role)) {
             // TODO: 본인 배송 주문만 (delivery-service 구현 후) 주석 제외
+            // 연관 ; JPARepository, Controller
             // delivery-service에서 본인 담당 deliveryId 목록 조회
 //            List<UUID> deliveryIds = deliveryClient
 //                    .getDeliveryIdsByDriver(userId, INTERNAL_REQUEST)

--- a/order-service/src/main/java/com/sparta/lucky/order/application/OrderService.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/application/OrderService.java
@@ -184,6 +184,10 @@ public class OrderService {
                                          UUID userId,
                                          Pageable pageable) {
         if ("MASTER".equals(role)) {
+            if (hubId != null && companyId != null) {
+                return orderRepository.findByHubAndCompany(
+                        hubId, companyId, status, pageable).map(OrderResponse::from);
+            }
             if (hubId != null) {
                 return orderRepository.findByOriginHubIdOrDestinationHubId(
                         hubId, hubId, status, pageable).map(OrderResponse::from);

--- a/order-service/src/main/java/com/sparta/lucky/order/application/OrderService.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/application/OrderService.java
@@ -37,7 +37,7 @@ public class OrderService {
     private static final String INTERNAL_REQUEST = "true";
     // 주문 생성
     @Transactional
-    public OrderResponse createOrder(CreateOrderCommand request) {
+    public OrderResponse createOrder(CreateOrderCommand request,String userId,String role) {
 
         // 1. 상품 조회 → productName, unitPrice, originHubId 확보
         ProductResponse product = productClient
@@ -48,7 +48,26 @@ public class OrderService {
         }
         // 재고 차감 후 순위로 미룸
 
-        // 2. 업체 조회 :
+        // 2. 업체가 요청한 주문일 때 → 인증 사용자와 대조
+        CompanyResponse requesterCompany = companyClient
+                .getCompany(request.getRequesterCompanyId(), INTERNAL_REQUEST)
+                .getData();
+        if (requesterCompany == null) {
+            throw new BusinessException(OrderErrorCode.COMPANY_NOT_FOUND);
+        }
+        // 업체에서 요청한 주문일 때는 해당 검증 확인
+        if ("COMPANY_MANAGER".equals(role)) {
+            UserResponse user = userClient
+                    .getUser(UUID.fromString(userId), INTERNAL_REQUEST)
+                    .getData();
+            if (user == null || user.getCompanyId() == null) {
+                throw new BusinessException(OrderErrorCode.COMPANY_NOT_FOUND);
+            }
+            // 본인 업체가 수령업체인지 확인
+            if (!user.getCompanyId().equals(request.getReceiverCompanyId())) {
+                throw new BusinessException(OrderErrorCode.ORDER_ACCESS_DENIED);
+            }
+        }
 
         // 3-1. 허브 조회 : 수령 업체 조회 → 도착 허브(destinationHubName), 도착 업체 주소(deliveryAddress) 확보
         CompanyResponse receiverCompany = companyClient

--- a/order-service/src/main/java/com/sparta/lucky/order/application/OrderService.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/application/OrderService.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 @Slf4j
@@ -45,18 +46,45 @@ public class OrderService {
         if (product == null) {
             throw new BusinessException(OrderErrorCode.PRODUCT_NOT_FOUND);
         }
+        // 재고 차감 후 순위로 미룸
 
-        // 2. 재고 차감 (실패 시 주문 롤백)
-        StockResponse stock = productClient
-                .decreaseStock(request.getProductId(),
-                        new StockUpdateRequest(request.getQuantity()),
-                        INTERNAL_REQUEST)
+        // 2. 업체 조회 :
+
+        // 3-1. 허브 조회 : 수령 업체 조회 → 도착 허브(destinationHubName), 도착 업체 주소(deliveryAddress) 확보
+        CompanyResponse receiverCompany = companyClient
+                .getCompany(request.getReceiverCompanyId(), INTERNAL_REQUEST)
                 .getData();
-        if (stock == null) {
-            throw new BusinessException(OrderErrorCode.OUT_OF_STOCK);
+        if (receiverCompany == null) {
+            throw new BusinessException(OrderErrorCode.COMPANY_NOT_FOUND);
         }
 
-        // 3. 주문 생성
+        // 3-2. 허브 조회 : 출발 허브 조회 → originHubName 확보
+        HubResponse originHub = hubClient
+                .getHub(product.getHubId(), INTERNAL_REQUEST)
+                .getData();
+        if (originHub == null) {
+            throw new BusinessException(OrderErrorCode.HUB_NOT_FOUND);
+        }
+
+        // 3-3. 허브 조회 : 도착 허브 조회 → destHubName, hubManagerId 확보
+        HubResponse destHub = hubClient
+                .getHub(receiverCompany.getHubId(),INTERNAL_REQUEST)
+                .getData();
+        if (destHub == null) {
+            throw new BusinessException(OrderErrorCode.HUB_NOT_FOUND);
+        }
+
+        // 4. 유저 조회 : 수령자 조회 → recipientName, recipientSlackId 확보
+        UserResponse recipient = userClient
+                .getUser(receiverCompany.getManager(), INTERNAL_REQUEST)
+                .getData();
+
+        // 4-1. 유저 조회 : 출발 허브 매니저 슬랙ID 조회
+        UserResponse hubManager = userClient
+                .getUser(originHub.getManagerId(), INTERNAL_REQUEST)
+                .getData();
+
+        // 5. 주문 생성
         Order order = Order.create(
                 request.getRequesterCompanyId(),
                 request.getReceiverCompanyId(),
@@ -68,41 +96,17 @@ public class OrderService {
                 request.getRequestedDeadline()
         );
 
-        // 4. 수령 업체 조회 → 도착 허브(destinationHubName), 도착 업체 주소(deliveryAddress) 확보
-        CompanyResponse receiverCompany = companyClient
-                .getCompany(request.getReceiverCompanyId(), INTERNAL_REQUEST)
+        // 6. 재고 차감 (실패 시 주문 롤백) <- 이동
+        StockResponse stock = productClient
+                .decreaseStock(request.getProductId(),
+                        new StockUpdateRequest(request.getQuantity()),
+                        INTERNAL_REQUEST)
                 .getData();
-        if (receiverCompany == null) {
-            throw new BusinessException(OrderErrorCode.COMPANY_NOT_FOUND);
+        if (stock == null) {
+            throw new BusinessException(OrderErrorCode.OUT_OF_STOCK);
         }
 
-        // 5. 출발 허브 조회 → originHubName 확보
-        HubResponse originHub = hubClient
-                .getHub(product.getHubId(), INTERNAL_REQUEST)
-                .getData();
-        if (originHub == null) {
-            throw new BusinessException(OrderErrorCode.HUB_NOT_FOUND);
-        }
-
-        // 6. 도착 허브 조회 → destHubName, hubManagerId 확보
-        HubResponse destHub = hubClient
-                .getHub(receiverCompany.getHubId(),INTERNAL_REQUEST)
-                .getData();
-        if (destHub == null) {
-            throw new BusinessException(OrderErrorCode.HUB_NOT_FOUND);
-        }
-
-        // 7. 수령자 조회 → recipientName, recipientSlackId 확보
-        UserResponse recipient = userClient
-                .getUser(receiverCompany.getManager(), INTERNAL_REQUEST)
-                .getData();
-
-        // 8. 출발 허브 매니저 슬랙ID 조회
-        UserResponse hubManager = userClient
-                .getUser(originHub.getManagerId(), INTERNAL_REQUEST)
-                .getData();
-
-        // 9. 배송 생성 → deliveryId 확보
+        // 7. 배송 생성 → deliveryId 확보
         DeliveryCreateResponse delivery = deliveryClient
                 .createDelivery(new DeliveryCreateRequest(
                         order.getId(),
@@ -113,13 +117,22 @@ public class OrderService {
                         request.getRequestedDeadline()
                 ), INTERNAL_REQUEST)
                 .getData();
+        if (delivery == null || delivery.getDeliveryId() == null) {
+            // 보상 트랜잭션: 재고 복원
+            productClient.restoreStock(
+                    request.getProductId(),
+                    new StockUpdateRequest(request.getQuantity()),
+                    INTERNAL_REQUEST
+            );
+            throw new BusinessException(OrderErrorCode.DELIVERY_CREATE_FAILED);
+        }
 
-        // 10. 주문에 배송 정보 업데이트
+        // 8. 주문에 배송 정보 업데이트
         order.updateDeliveryInfo(
                 //  -> 랜덤값
-                delivery != null ? delivery.getDeliveryId() : UUID.randomUUID(),
-                originHub.getHubId(),    // 추가
-                destHub.getHubId(),      // 추가
+                delivery.getDeliveryId(),
+                originHub.getHubId(),
+                destHub.getHubId(),
                 originHub.getName(),
                 destHub.getName(),
                 receiverCompany.getAddress(),
@@ -165,15 +178,26 @@ public class OrderService {
             return orderRepository.findByRequesterCompanyIdOrReceiverCompanyId(
                             user.getCompanyId(), user.getCompanyId(), status, pageable)
                     .map(OrderResponse::from);
+        } //else if ("DELIVERY_DRIVER".equals(role)) {
+            // TODO: 본인 배송 주문만 (delivery-service 구현 후) 주석 제외
+            // delivery-service에서 본인 담당 deliveryId 목록 조회
+//            List<UUID> deliveryIds = deliveryClient
+//                    .getDeliveryIdsByDriver(userId, INTERNAL_REQUEST)
+//                    .getData();
+//            if (deliveryIds == null || deliveryIds.isEmpty()) {
+//                return Page.empty(pageable);
+//            }
+//            if (status != null) {
+//                return orderRepository.findByDeliveryIdInAndStatus(deliveryIds, status, pageable)
+//                        .map(OrderResponse::from);
+//            }
+//            return orderRepository.findByDeliveryIdIn(deliveryIds, pageable)
+//                    .map(OrderResponse::from);
 
-        } else {
-            // DELIVERY_DRIVER 등
-            if (status != null) {
-                return orderRepository.findByStatus(status, pageable)
-                        .map(OrderResponse::from);
-            }
-            return orderRepository.findAll(pageable)
-                    .map(OrderResponse::from);
+        //}
+        else {
+            // 미허용 역할 → 접근 거부
+            throw new BusinessException(OrderErrorCode.ORDER_ACCESS_DENIED);
         }
     }
 
@@ -194,22 +218,28 @@ public class OrderService {
     @Transactional
     public OrderResponse cancelOrder(UUID id) {
         Order order = findOrderById(id);
-        // 1. 배송 상태 확인: deliveryClient.getDeliveryStatus(id)
-        //    → WAITING 아니면 에러
+
+        // 1. 먼저 주문 상태 검증 (이미 취소/완료된 주문이면 외부 호출 전에 차단)
+        if (order.getStatus() != OrderStatus.CREATED) {
+            throw new BusinessException(OrderErrorCode.INVALID_ORDER_STATUS);
+        }
+
+        // 2. 배송 상태 확인
         DeliveryStatusResponse status = deliveryClient
                 .getDeliveryStatus(id, INTERNAL_REQUEST)
                 .getData();
         if (status != null && !"WAITING".equals(status.getDeliveryStatus())) {
             throw new BusinessException(OrderErrorCode.INVALID_ORDER_STATUS);
         }
-        // 2. 재고 복원: productClient.restoreStock(productId, quantity)
+
+        // 3. 재고 복원
         productClient.restoreStock(
                 order.getProductId(),
                 new StockUpdateRequest(order.getQuantity()),
                 INTERNAL_REQUEST
         );
 
-        // TODO: 3. 배송 취소 API (delivery-service 구현 후 추가)
+        // TODO: 4. 배송 취소 API
         order.cancel();
         return OrderResponse.from(order);
     }

--- a/order-service/src/main/java/com/sparta/lucky/order/application/OrderService.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/application/OrderService.java
@@ -131,14 +131,53 @@ public class OrderService {
 
     }
 
-    // 주문 목록 조회 (페이징 + status 필터)
-    public Page<OrderResponse> getOrders(OrderStatus status, Pageable pageable) {
-        if (status != null) {
-            return orderRepository.findByStatus(status, pageable)
+    // 주문 목록 조회 (페이징 + status 필터 + 역할별 조회 결과 다르게)
+    public Page<OrderResponse> getOrders(OrderStatus status,
+                                         String role,
+                                         UUID userId,
+                                         Pageable pageable) {
+
+        if ("MASTER".equals(role)) {
+            if (status != null) {
+                return orderRepository.findByStatus(status, pageable)
+                        .map(OrderResponse::from);
+            }
+            return orderRepository.findAll(pageable)
+                    .map(OrderResponse::from);
+
+        } else if ("HUB_MANAGER".equals(role)) {
+            // userId로 user-service 조회 → hubId 확보 → hub-service 조회 → 허브명 확보
+            UserResponse user = userClient.getUser(userId, INTERNAL_REQUEST).getData();
+            if (user == null || user.getHubId() == null) {
+                throw new BusinessException(OrderErrorCode.HUB_NOT_FOUND);
+            }
+            HubResponse hub = hubClient.getHub(user.getHubId(), INTERNAL_REQUEST).getData();
+            if (hub == null) {
+                throw new BusinessException(OrderErrorCode.HUB_NOT_FOUND);
+            }
+            return orderRepository.findByOriginHubNameOrDestinationHubName(
+                            hub.getName(), hub.getName(), status, pageable)
+                    .map(OrderResponse::from);
+
+        } else if ("COMPANY_MANAGER".equals(role)) {
+            // userId로 user-service 조회 → companyId 확보
+            UserResponse user = userClient.getUser(userId, INTERNAL_REQUEST).getData();
+            if (user == null || user.getCompanyId() == null) {
+                throw new BusinessException(OrderErrorCode.COMPANY_NOT_FOUND);
+            }
+            return orderRepository.findByRequesterCompanyIdOrReceiverCompanyId(
+                            user.getCompanyId(), user.getCompanyId(), status, pageable)
+                    .map(OrderResponse::from);
+
+        } else {
+            // DELIVERY_DRIVER 등
+            if (status != null) {
+                return orderRepository.findByStatus(status, pageable)
+                        .map(OrderResponse::from);
+            }
+            return orderRepository.findAll(pageable)
                     .map(OrderResponse::from);
         }
-        return orderRepository.findAll(pageable)
-                .map(OrderResponse::from);
     }
 
     // 주문 단건 조회

--- a/order-service/src/main/java/com/sparta/lucky/order/application/OrderService.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/application/OrderService.java
@@ -2,8 +2,8 @@ package com.sparta.lucky.order.application;
 
 import com.sparta.lucky.order.application.dto.CreateOrderCommand;
 import com.sparta.lucky.order.application.dto.OrderInternalResponse;
-import com.sparta.lucky.order.application.dto.UpdateOrderCommand;
 import com.sparta.lucky.order.application.dto.OrderResponse;
+import com.sparta.lucky.order.application.dto.UpdateOrderCommand;
 import com.sparta.lucky.order.common.exception.BusinessException;
 import com.sparta.lucky.order.common.exception.OrderErrorCode;
 import com.sparta.lucky.order.domain.Order;
@@ -18,7 +18,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.UUID;
 
 @Slf4j

--- a/order-service/src/main/java/com/sparta/lucky/order/application/OrderService.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/application/OrderService.java
@@ -9,6 +9,8 @@ import com.sparta.lucky.order.common.exception.OrderErrorCode;
 import com.sparta.lucky.order.domain.Order;
 import com.sparta.lucky.order.domain.OrderRepository;
 import com.sparta.lucky.order.domain.OrderStatus;
+import com.sparta.lucky.order.infrastructure.client.*;
+import com.sparta.lucky.order.infrastructure.client.dto.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -25,48 +27,108 @@ import java.util.UUID;
 public class OrderService {
 
     private final OrderRepository orderRepository;
+    private final ProductClient productClient;
+    private final CompanyClient companyClient;
+    private final HubClient hubClient;
+    private final UserClient userClient;
+    private final DeliveryClient deliveryClient;
 
+    private static final String INTERNAL_REQUEST = "true";
     // 주문 생성
     @Transactional
     public OrderResponse createOrder(CreateOrderCommand request) {
 
-    /*
-     * TODO: FeignClient 연동 시 구현 company-service 호출
-     * 1. 상품 조회: companyClient.getProduct(productId, "true")
-     * 2. 재고 차감: companyClient.decreaseStock(productId, quantity, "true")
-     *
-     * */
-        String productName = "더미상품";
-        Integer unitPrice = 1000;
+        // 1. 상품 조회 → productName, unitPrice, originHubId 확보
+        ProductResponse product = productClient
+                .getProduct(request.getProductId(),INTERNAL_REQUEST)
+                .getData();
+        if (product == null) {
+            throw new BusinessException(OrderErrorCode.PRODUCT_NOT_FOUND);
+        }
 
+        // 2. 재고 차감 (실패 시 주문 롤백)
+        StockResponse stock = productClient
+                .decreaseStock(request.getProductId(),
+                        new StockUpdateRequest(request.getQuantity()),
+                        INTERNAL_REQUEST)
+                .getData();
+        if (stock == null) {
+            throw new BusinessException(OrderErrorCode.OUT_OF_STOCK);
+        }
+
+        // 3. 주문 생성
         Order order = Order.create(
                 request.getRequesterCompanyId(),
                 request.getReceiverCompanyId(),
                 request.getProductId(),
-                productName,
+                product.getName(),
                 request.getQuantity(),
-                unitPrice,
+                product.getPrice(),
                 request.getRequestNote(),
                 request.getRequestedDeadline()
         );
 
-    /*
-    * TODO: FeignClient 연동 시 구현 delivery-service, hub-service 호출 -> 실제 응답으로 교체
-    * 3. 배송 생성: deliveryClient.createDelivery(...)
-    * 4. 허브 조회: hubClient.getHub(hubId, "true")
-    * */
-        order.updateDeliveryInfo(
-                UUID.randomUUID(),      // deliveryId
-                "더미출발허브",           // originHubName
-                "더미도착허브",           // destinationHubName
-                "더미배송주소",           // deliveryAddress
-                "더미수신자",            // recipientName
-                "더미수신자슬랙ID",            // recipientSlackId
-                "더미허브매니저슬랙ID"    // hubManagerSlackId
-        );
-        Order savedOrder = orderRepository.save(order);
+        // 4. 수령 업체 조회 → 도착 허브(destinationHubName), 도착 업체 주소(deliveryAddress) 확보
+        CompanyResponse receiverCompany = companyClient
+                .getCompany(request.getReceiverCompanyId(), INTERNAL_REQUEST)
+                .getData();
+        if (receiverCompany == null) {
+            throw new BusinessException(OrderErrorCode.COMPANY_NOT_FOUND);
+        }
 
+        // 5. 출발 허브 조회 → originHubName 확보
+        HubResponse originHub = hubClient
+                .getHub(product.getHubId(), INTERNAL_REQUEST)
+                .getData();
+        if (originHub == null) {
+            throw new BusinessException(OrderErrorCode.HUB_NOT_FOUND);
+        }
+
+        // 6. 도착 허브 조회 → destHubName, hubManagerId 확보
+        HubResponse destHub = hubClient
+                .getHub(receiverCompany.getHubId(),INTERNAL_REQUEST)
+                .getData();
+        if (destHub == null) {
+            throw new BusinessException(OrderErrorCode.HUB_NOT_FOUND);
+        }
+
+        // 7. 수령자 조회 → recipientName, recipientSlackId 확보
+        UserResponse recipient = userClient
+                .getUser(receiverCompany.getManager(), INTERNAL_REQUEST)
+                .getData();
+
+        // 8. 출발 허브 매니저 슬랙ID 조회
+        UserResponse hubManager = userClient
+                .getUser(originHub.getManagerId(), INTERNAL_REQUEST)
+                .getData();
+
+        // 9. 배송 생성 → deliveryId 확보
+        DeliveryCreateResponse delivery = deliveryClient
+                .createDelivery(new DeliveryCreateRequest(
+                        order.getId(),
+                        request.getReceiverCompanyId(),
+                        product.getHubId(),
+                        recipient != null ? recipient.getName() : "미확인",
+                        recipient != null ? recipient.getReceiverSlackId() : "",
+                        request.getRequestedDeadline()
+                ), INTERNAL_REQUEST)
+                .getData();
+
+        // 10. 주문에 배송 정보 업데이트
+        order.updateDeliveryInfo(
+                //  -> 랜덤값
+                delivery != null ? delivery.getDeliveryId() : UUID.randomUUID(),
+                originHub.getName(),
+                destHub.getName(),
+                receiverCompany.getAddress(),
+                recipient != null ? recipient.getName() : "미확인",
+                recipient != null ? recipient.getReceiverSlackId() : "",
+                hubManager != null ? hubManager.getReceiverSlackId() : ""
+        );
+
+        Order savedOrder = orderRepository.save(order);
         return OrderResponse.from(savedOrder);
+
     }
 
     // 주문 목록 조회 (페이징 + status 필터)
@@ -96,13 +158,22 @@ public class OrderService {
     @Transactional
     public OrderResponse cancelOrder(UUID id) {
         Order order = findOrderById(id);
-    /*
-    * TODO: FeignClient 연동 시 구현
-    * 1. 배송 상태 확인: deliveryClient.getDeliveryStatus(orderId)
-    *    → WAITING이 아니면 에러
-    * 2. 재고 복원: companyClient.restoreStock(productId, quantity, "true")
-    * 3. 배송 취소: deliveryClient.cancelDelivery(deliveryId)
-    */
+        // 1. 배송 상태 확인: deliveryClient.getDeliveryStatus(id)
+        //    → WAITING 아니면 에러
+        DeliveryStatusResponse status = deliveryClient
+                .getDeliveryStatus(id, INTERNAL_REQUEST)
+                .getData();
+        if (status != null && !"WAITING".equals(status.getDeliveryStatus())) {
+            throw new BusinessException(OrderErrorCode.INVALID_ORDER_STATUS);
+        }
+        // 2. 재고 복원: productClient.restoreStock(productId, quantity)
+        productClient.restoreStock(
+                order.getProductId(),
+                new StockUpdateRequest(order.getQuantity()),
+                INTERNAL_REQUEST
+        );
+
+        // TODO: 3. 배송 취소 API (delivery-service 구현 후 추가)
         order.cancel();
         return OrderResponse.from(order);
     }

--- a/order-service/src/main/java/com/sparta/lucky/order/application/OrderService.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/application/OrderService.java
@@ -160,7 +160,6 @@ public class OrderService {
 
         // 8. 주문에 배송 정보 업데이트
         order.updateDeliveryInfo(
-                //  -> 랜덤값
                 delivery.getDeliveryId(),
                 originHub.getHubId(),
                 destHub.getHubId(),
@@ -178,25 +177,38 @@ public class OrderService {
     }
 
     // 주문 목록 조회 (페이징 + status 필터 + 역할별 조회 결과 다르게)
+    // 목록을 조회 하는건 마스터, 허브 매니저, 업체 매니저 만 가능
     public Page<OrderResponse> getOrders(OrderStatus status,
                                          String role,
+                                         UUID hubId,
+                                         UUID companyId,
                                          UUID userId,
                                          Pageable pageable) {
-
         if ("MASTER".equals(role)) {
-            if (status != null) {
-                return orderRepository.findByStatus(status, pageable)
-                        .map(OrderResponse::from);
+            if (hubId != null) {
+                return orderRepository.findByOriginHubIdOrDestinationHubId(
+                        hubId, hubId, status, pageable).map(OrderResponse::from);
             }
-            return orderRepository.findAll(pageable)
-                    .map(OrderResponse::from);
+            if (companyId != null) {
+                return orderRepository.findByRequesterCompanyIdOrReceiverCompanyId(
+                        companyId, companyId, status, pageable).map(OrderResponse::from);
+            }
+            // hubId, companyId 없으면 status만 or 전체
+            if (status != null) {
+                return orderRepository.findByStatus(status, pageable).map(OrderResponse::from);
+            }
+            return orderRepository.findAll(pageable).map(OrderResponse::from);
 
         } else if ("HUB_MANAGER".equals(role)) {
             UserResponse user = userClient.getUser(userId, INTERNAL_REQUEST).getData();
             if (user == null || user.getHubId() == null) {
                 throw new BusinessException(OrderErrorCode.HUB_NOT_FOUND);
             }
-            // hub-service 호출 없이 hubId로 바로 필터링!
+            // 업체별 필터
+            if (companyId != null) {
+                return orderRepository.findByHubAndCompany(
+                        user.getHubId(), companyId, status, pageable).map(OrderResponse::from);
+            }
             return orderRepository.findByOriginHubIdOrDestinationHubId(
                             user.getHubId(), user.getHubId(), status, pageable)
                     .map(OrderResponse::from);
@@ -209,24 +221,7 @@ public class OrderService {
             return orderRepository.findByRequesterCompanyIdOrReceiverCompanyId(
                             user.getCompanyId(), user.getCompanyId(), status, pageable)
                     .map(OrderResponse::from);
-        } //else if ("DELIVERY_DRIVER".equals(role)) {
-            // TODO: 본인 배송 주문만 (delivery-service 구현 후) 주석 제외
-            // 연관 ; JPARepository, Controller
-            // delivery-service에서 본인 담당 deliveryId 목록 조회
-//            List<UUID> deliveryIds = deliveryClient
-//                    .getDeliveryIdsByDriver(userId, INTERNAL_REQUEST)
-//                    .getData();
-//            if (deliveryIds == null || deliveryIds.isEmpty()) {
-//                return Page.empty(pageable);
-//            }
-//            if (status != null) {
-//                return orderRepository.findByDeliveryIdInAndStatus(deliveryIds, status, pageable)
-//                        .map(OrderResponse::from);
-//            }
-//            return orderRepository.findByDeliveryIdIn(deliveryIds, pageable)
-//                    .map(OrderResponse::from);
-
-        //}
+        }
         else {
             // 미허용 역할 → 접근 거부
             throw new BusinessException(OrderErrorCode.ORDER_ACCESS_DENIED);
@@ -234,6 +229,7 @@ public class OrderService {
     }
 
     // 주문 단건 조회
+    // 모든 역할 가능
     public OrderResponse getOrder(UUID id) {
         return OrderResponse.from(findOrderById(id));
     }
@@ -271,7 +267,8 @@ public class OrderService {
                 INTERNAL_REQUEST
         );
 
-        // TODO: 4. 배송 취소 API
+        // TODO: 4. 배송 취소 API 구현되면 추가
+        // // deliveryClient.cancelDelivery(order.getDeliveryId(), INTERNAL_REQUEST);
         order.cancel();
         return OrderResponse.from(order);
     }

--- a/order-service/src/main/java/com/sparta/lucky/order/application/OrderService.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/application/OrderService.java
@@ -118,6 +118,8 @@ public class OrderService {
         order.updateDeliveryInfo(
                 //  -> 랜덤값
                 delivery != null ? delivery.getDeliveryId() : UUID.randomUUID(),
+                originHub.getHubId(),    // 추가
+                destHub.getHubId(),      // 추가
                 originHub.getName(),
                 destHub.getName(),
                 receiverCompany.getAddress(),
@@ -146,19 +148,14 @@ public class OrderService {
                     .map(OrderResponse::from);
 
         } else if ("HUB_MANAGER".equals(role)) {
-            // userId로 user-service 조회 → hubId 확보 → hub-service 조회 → 허브명 확보
             UserResponse user = userClient.getUser(userId, INTERNAL_REQUEST).getData();
             if (user == null || user.getHubId() == null) {
                 throw new BusinessException(OrderErrorCode.HUB_NOT_FOUND);
             }
-            HubResponse hub = hubClient.getHub(user.getHubId(), INTERNAL_REQUEST).getData();
-            if (hub == null) {
-                throw new BusinessException(OrderErrorCode.HUB_NOT_FOUND);
-            }
-            return orderRepository.findByOriginHubNameOrDestinationHubName(
-                            hub.getName(), hub.getName(), status, pageable)
+            // hub-service 호출 없이 hubId로 바로 필터링!
+            return orderRepository.findByOriginHubIdOrDestinationHubId(
+                            user.getHubId(), user.getHubId(), status, pageable)
                     .map(OrderResponse::from);
-
         } else if ("COMPANY_MANAGER".equals(role)) {
             // userId로 user-service 조회 → companyId 확보
             UserResponse user = userClient.getUser(userId, INTERNAL_REQUEST).getData();

--- a/order-service/src/main/java/com/sparta/lucky/order/common/config/AuditConfig.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/common/config/AuditConfig.java
@@ -16,6 +16,9 @@ import java.util.UUID;
 @EnableJpaAuditing
 public class AuditConfig {
 
+    private static final UUID SYSTEM_ID =
+            UUID.fromString("00000000-0000-0000-0000-000000000000");
+
     @Bean
     public AuditorAware<UUID> auditorAware() {
         return () -> {
@@ -23,10 +26,10 @@ public class AuditConfig {
                 // Gateway가 주입한 X-User-Id 헤더에서 현재 요청자 UUID 추출
                 ServletRequestAttributes attrs =
                         (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
-                if (attrs == null) return Optional.empty();
+                if (attrs == null) return Optional.of(SYSTEM_ID);
 
                 String userId = attrs.getRequest().getHeader("X-User-Id");
-                if (userId == null || userId.isBlank()) return Optional.empty();
+                if (userId == null || userId.isBlank()) return Optional.of(SYSTEM_ID);
 
                 return Optional.of(UUID.fromString(userId));
             } catch (Exception e) {

--- a/order-service/src/main/java/com/sparta/lucky/order/common/config/SecurityConfig.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/common/config/SecurityConfig.java
@@ -1,15 +1,25 @@
 package com.sparta.lucky.order.common.config;
 
+import com.sparta.lucky.order.common.filter.HeaderAuthenticationFilter;
+import com.sparta.lucky.order.common.filter.InternalRequestFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final HeaderAuthenticationFilter headerAuthenticationFilter;
+    private final InternalRequestFilter internalRequestFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -20,6 +30,10 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll() // Swagger
                         .anyRequest().authenticated()
                 )
+                .addFilterBefore(headerAuthenticationFilter,
+                        UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(internalRequestFilter,
+                        HeaderAuthenticationFilter.class)
                 .oauth2ResourceServer(oauth -> oauth.jwt(Customizer.withDefaults()));
         return http.build();
     }

--- a/order-service/src/main/java/com/sparta/lucky/order/common/config/SecurityConfig.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/common/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.sparta.lucky.order.common.config;
 import com.sparta.lucky.order.common.filter.HeaderAuthenticationFilter;
 import com.sparta.lucky.order.common.filter.InternalRequestFilter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -36,5 +37,31 @@ public class SecurityConfig {
                         HeaderAuthenticationFilter.class)
                 .oauth2ResourceServer(oauth -> oauth.jwt(Customizer.withDefaults()));
         return http.build();
+    }
+
+    @Bean
+    public HeaderAuthenticationFilter headerAuthenticationFilter() {
+        return new HeaderAuthenticationFilter();
+    }
+
+    @Bean
+    public InternalRequestFilter internalRequestFilter() {
+        return new InternalRequestFilter();
+    }
+
+    @Bean
+    public FilterRegistrationBean<HeaderAuthenticationFilter> headerFilterRegistration(
+            HeaderAuthenticationFilter filter) {
+        FilterRegistrationBean<HeaderAuthenticationFilter> bean = new FilterRegistrationBean<>(filter);
+        bean.setEnabled(false); // 서블릿 자동 등록 비활성화
+        return bean;
+    }
+
+    @Bean
+    public FilterRegistrationBean<InternalRequestFilter> internalFilterRegistration(
+            InternalRequestFilter filter) {
+        FilterRegistrationBean<InternalRequestFilter> bean = new FilterRegistrationBean<>(filter);
+        bean.setEnabled(false);
+        return bean;
     }
 }

--- a/order-service/src/main/java/com/sparta/lucky/order/common/config/SecurityConfig.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/common/config/SecurityConfig.java
@@ -40,27 +40,17 @@ public class SecurityConfig {
     }
 
     @Bean
-    public HeaderAuthenticationFilter headerAuthenticationFilter() {
-        return new HeaderAuthenticationFilter();
-    }
-
-    @Bean
-    public InternalRequestFilter internalRequestFilter() {
-        return new InternalRequestFilter();
-    }
-
-    @Bean
-    public FilterRegistrationBean<HeaderAuthenticationFilter> headerFilterRegistration(
-            HeaderAuthenticationFilter filter) {
-        FilterRegistrationBean<HeaderAuthenticationFilter> bean = new FilterRegistrationBean<>(filter);
+    public FilterRegistrationBean<HeaderAuthenticationFilter> headerFilterRegistration() {
+        FilterRegistrationBean<HeaderAuthenticationFilter> bean =
+                new FilterRegistrationBean<>(headerAuthenticationFilter);
         bean.setEnabled(false); // 서블릿 자동 등록 비활성화
         return bean;
     }
 
     @Bean
-    public FilterRegistrationBean<InternalRequestFilter> internalFilterRegistration(
-            InternalRequestFilter filter) {
-        FilterRegistrationBean<InternalRequestFilter> bean = new FilterRegistrationBean<>(filter);
+    public FilterRegistrationBean<InternalRequestFilter> internalFilterRegistration() {
+        FilterRegistrationBean<InternalRequestFilter> bean =
+                new FilterRegistrationBean<>(internalRequestFilter);
         bean.setEnabled(false);
         return bean;
     }

--- a/order-service/src/main/java/com/sparta/lucky/order/common/exception/OrderErrorCode.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/common/exception/OrderErrorCode.java
@@ -20,7 +20,8 @@ public enum OrderErrorCode implements ErrorCode {
 
     OUT_OF_STOCK ("ORD_008", "재고가 부족하여 주문할 수 없습니다.", 409),
     PRODUCT_NOT_FOUND ("ORD_009", "존재하지 않는 상품입니다.", 404),
-
+    COMPANY_NOT_FOUND ("ORD_010","존재하지 않는 업체입니다.",404),
+    HUB_NOT_FOUND("ORD_011","존재하지 않는 허브입니다.",404),
     ;
 
     private final String code;

--- a/order-service/src/main/java/com/sparta/lucky/order/common/exception/OrderErrorCode.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/common/exception/OrderErrorCode.java
@@ -22,6 +22,8 @@ public enum OrderErrorCode implements ErrorCode {
     PRODUCT_NOT_FOUND ("ORD_009", "존재하지 않는 상품입니다.", 404),
     COMPANY_NOT_FOUND ("ORD_010","존재하지 않는 업체입니다.",404),
     HUB_NOT_FOUND("ORD_011","존재하지 않는 허브입니다.",404),
+    DELIVERY_CREATE_FAILED("ORD_012", "배송 생성에 실패했습니다.", 500),
+
     ;
 
     private final String code;

--- a/order-service/src/main/java/com/sparta/lucky/order/common/filter/HeaderAuthenticationFilter.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/common/filter/HeaderAuthenticationFilter.java
@@ -4,6 +4,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.lang.NonNull;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -17,9 +18,9 @@ import java.util.List;
 public class HeaderAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request,
-                                    HttpServletResponse response,
-                                    FilterChain filterChain) throws ServletException, IOException {
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain) throws ServletException, IOException {
         String userId = request.getHeader("X-User-Id");
         String role = request.getHeader("X-User-Role");
 

--- a/order-service/src/main/java/com/sparta/lucky/order/common/filter/HeaderAuthenticationFilter.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/common/filter/HeaderAuthenticationFilter.java
@@ -14,6 +14,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.util.List;
 
+@Component
 public class HeaderAuthenticationFilter extends OncePerRequestFilter {
 
     @Override

--- a/order-service/src/main/java/com/sparta/lucky/order/common/filter/HeaderAuthenticationFilter.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/common/filter/HeaderAuthenticationFilter.java
@@ -14,7 +14,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.util.List;
 
-@Component
 public class HeaderAuthenticationFilter extends OncePerRequestFilter {
 
     @Override

--- a/order-service/src/main/java/com/sparta/lucky/order/common/filter/HeaderAuthenticationFilter.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/common/filter/HeaderAuthenticationFilter.java
@@ -1,0 +1,37 @@
+package com.sparta.lucky.order.common.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+public class HeaderAuthenticationFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String userId = request.getHeader("X-User-Id");
+        String role = request.getHeader("X-User-Role");
+
+        if (userId != null && !userId.isBlank() && role != null && !role.isBlank()) {
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            userId,
+                            null,
+                            List.of(new SimpleGrantedAuthority("ROLE_" + role))
+                    );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/order-service/src/main/java/com/sparta/lucky/order/common/filter/InternalRequestFilter.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/common/filter/InternalRequestFilter.java
@@ -1,40 +1,47 @@
 package com.sparta.lucky.order.common.filter;
 
-import com.sparta.lucky.order.common.exception.BusinessException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sparta.lucky.order.common.exception.OrderErrorCode;
+import com.sparta.lucky.order.common.response.ApiResponse;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+@Component
+@RequiredArgsConstructor
 public class InternalRequestFilter extends OncePerRequestFilter {
 
     private static final String INTERNAL_PATH_PREFIX = "/internal/";
     private static final String INTERNAL_HEADER = "X-Internal-Request";
-
-//    @Value("${security.internal-request.secret}")
-//    private String internalRequestSecret;
+    private final ObjectMapper objectMapper;
 
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request,
                                     @NonNull HttpServletResponse response,
                                     @NonNull FilterChain filterChain) throws ServletException, IOException {
         if (request.getRequestURI().startsWith(INTERNAL_PATH_PREFIX)) {
-            validateInternalRequest(request.getHeader(INTERNAL_HEADER));
+            String internalHeader = request.getHeader(INTERNAL_HEADER);
+            if (internalHeader == null || internalHeader.isBlank()) {
+                sendErrorResponse(response);
+                return;
+            }
         }
         filterChain.doFilter(request, response);
     }
 
-    private void validateInternalRequest(String internalRequest) {
-        if (internalRequest == null || internalRequest.isBlank()) {
-            throw new BusinessException(OrderErrorCode.ORDER_ACCESS_DENIED);
-        }
-//        if (!internalRequestSecret.equals(internalRequest)) {
-//            throw new BusinessException(OrderErrorCode.ORDER_ACCESS_DENIED);
-//        }
+    private void sendErrorResponse(HttpServletResponse response) throws IOException {
+        response.setStatus(OrderErrorCode.ORDER_ACCESS_DENIED.getHttpStatus());
+        response.setContentType("application/json;charset=UTF-8");
+        ApiResponse<Void> errorResponse = ApiResponse.error(
+                OrderErrorCode.ORDER_ACCESS_DENIED.getCode(),
+                OrderErrorCode.ORDER_ACCESS_DENIED.getMessage());
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
     }
 }

--- a/order-service/src/main/java/com/sparta/lucky/order/common/filter/InternalRequestFilter.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/common/filter/InternalRequestFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Component;
+import org.springframework.lang.NonNull;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -18,9 +19,9 @@ public class InternalRequestFilter extends OncePerRequestFilter {
     private static final String INTERNAL_HEADER = "X-Internal-Request";
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request,
-                                    HttpServletResponse response,
-                                    FilterChain filterChain) throws ServletException, IOException {
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain) throws ServletException, IOException {
         if (request.getRequestURI().startsWith(INTERNAL_PATH_PREFIX)) {
             validateInternalRequest(request.getHeader(INTERNAL_HEADER));
         }

--- a/order-service/src/main/java/com/sparta/lucky/order/common/filter/InternalRequestFilter.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/common/filter/InternalRequestFilter.java
@@ -6,17 +6,18 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.stereotype.Component;
 import org.springframework.lang.NonNull;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
-@Component
 public class InternalRequestFilter extends OncePerRequestFilter {
 
     private static final String INTERNAL_PATH_PREFIX = "/internal/";
     private static final String INTERNAL_HEADER = "X-Internal-Request";
+
+//    @Value("${security.internal-request.secret}")
+//    private String internalRequestSecret;
 
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request,
@@ -32,5 +33,8 @@ public class InternalRequestFilter extends OncePerRequestFilter {
         if (internalRequest == null || internalRequest.isBlank()) {
             throw new BusinessException(OrderErrorCode.ORDER_ACCESS_DENIED);
         }
+//        if (!internalRequestSecret.equals(internalRequest)) {
+//            throw new BusinessException(OrderErrorCode.ORDER_ACCESS_DENIED);
+//        }
     }
 }

--- a/order-service/src/main/java/com/sparta/lucky/order/common/filter/InternalRequestFilter.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/common/filter/InternalRequestFilter.java
@@ -1,0 +1,35 @@
+package com.sparta.lucky.order.common.filter;
+
+import com.sparta.lucky.order.common.exception.BusinessException;
+import com.sparta.lucky.order.common.exception.OrderErrorCode;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class InternalRequestFilter extends OncePerRequestFilter {
+
+    private static final String INTERNAL_PATH_PREFIX = "/internal/";
+    private static final String INTERNAL_HEADER = "X-Internal-Request";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        if (request.getRequestURI().startsWith(INTERNAL_PATH_PREFIX)) {
+            validateInternalRequest(request.getHeader(INTERNAL_HEADER));
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private void validateInternalRequest(String internalRequest) {
+        if (internalRequest == null || internalRequest.isBlank()) {
+            throw new BusinessException(OrderErrorCode.ORDER_ACCESS_DENIED);
+        }
+    }
+}

--- a/order-service/src/main/java/com/sparta/lucky/order/domain/Order.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/domain/Order.java
@@ -51,6 +51,8 @@ public class Order extends BaseEntity {
     private UUID deliveryId;
 
     // 알림용 저장
+    private UUID originHubId;
+    private UUID destinationHubId;
     private String originHubName;
     private String destinationHubName;
     private String deliveryAddress;
@@ -103,6 +105,8 @@ public class Order extends BaseEntity {
     // 배송 정보 받아오면 정보 업데이트
     public void updateDeliveryInfo(
             UUID deliveryId,
+            UUID originHubId,       // 추가
+            UUID destinationHubId,  // 추가
             String originHubName,
             String destinationHubName,
             String deliveryAddress,
@@ -114,6 +118,8 @@ public class Order extends BaseEntity {
         this.deliveryId = deliveryId;
         this.originHubName = originHubName;
         this.destinationHubName = destinationHubName;
+        this.originHubId = originHubId;         // 추가
+        this.destinationHubId = destinationHubId; // 추가
         this.deliveryAddress = deliveryAddress;
         this.recipientName = recipientName;
         this.recipientSlackId = recipientSlackId;

--- a/order-service/src/main/java/com/sparta/lucky/order/domain/OrderRepository.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/domain/OrderRepository.java
@@ -17,9 +17,10 @@ public interface OrderRepository {
             UUID requesterCompanyId, UUID receiverCompanyId,
             OrderStatus status, Pageable pageable);
 
-    // 허브 매니저용
-    Page<Order> findByOriginHubNameOrDestinationHubName(
-            String originHubName, String destinationHubName,
+    // 허브 매니저용 - 기존 허브명 조회 제거하고 hubId 조회로 교체
+    Page<Order> findByOriginHubIdOrDestinationHubId(
+            UUID originHubId, UUID destinationHubId,
             OrderStatus status, Pageable pageable);
+
 
 }

--- a/order-service/src/main/java/com/sparta/lucky/order/domain/OrderRepository.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/domain/OrderRepository.java
@@ -3,7 +3,6 @@ package com.sparta.lucky.order.domain;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -23,9 +22,10 @@ public interface OrderRepository {
             UUID originHubId, UUID destinationHubId,
             OrderStatus status, Pageable pageable);
 
-    // 배송 담당자용
-    Page<Order> findByDeliveryIdIn(List<UUID> deliveryIds, Pageable pageable);
-    Page<Order> findByDeliveryIdInAndStatus(List<UUID> deliveryIds, OrderStatus status, Pageable pageable);
+    Page<Order> findByHubAndCompany(UUID hubId,
+                                    UUID companyId,
+                                    OrderStatus status,
+                                    Pageable pageable);
 
 
 }

--- a/order-service/src/main/java/com/sparta/lucky/order/domain/OrderRepository.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/domain/OrderRepository.java
@@ -11,4 +11,15 @@ public interface OrderRepository {
     Optional<Order> findById(UUID id);
     Page<Order> findAll(Pageable pageable);
     Page<Order> findByStatus(OrderStatus status, Pageable pageable);
+
+    // 업체 담당자용
+    Page<Order> findByRequesterCompanyIdOrReceiverCompanyId(
+            UUID requesterCompanyId, UUID receiverCompanyId,
+            OrderStatus status, Pageable pageable);
+
+    // 허브 매니저용
+    Page<Order> findByOriginHubNameOrDestinationHubName(
+            String originHubName, String destinationHubName,
+            OrderStatus status, Pageable pageable);
+
 }

--- a/order-service/src/main/java/com/sparta/lucky/order/domain/OrderRepository.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/domain/OrderRepository.java
@@ -3,6 +3,7 @@ package com.sparta.lucky.order.domain;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -21,6 +22,10 @@ public interface OrderRepository {
     Page<Order> findByOriginHubIdOrDestinationHubId(
             UUID originHubId, UUID destinationHubId,
             OrderStatus status, Pageable pageable);
+
+    // 배송 담당자용
+    Page<Order> findByDeliveryIdIn(List<UUID> deliveryIds, Pageable pageable);
+    Page<Order> findByDeliveryIdInAndStatus(List<UUID> deliveryIds, OrderStatus status, Pageable pageable);
 
 
 }

--- a/order-service/src/main/java/com/sparta/lucky/order/infrastructure/OrderJpaRepository.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/infrastructure/OrderJpaRepository.java
@@ -20,12 +20,12 @@ public interface OrderJpaRepository extends JpaRepository<Order, UUID> {
             Pageable pageable);
 
     // 허브 매니저용
-    Page<Order> findByOriginHubNameOrDestinationHubNameAndStatus(
-            String originHubName, String destinationHubName,
+    Page<Order> findByOriginHubIdOrDestinationHubIdAndStatus(
+            UUID originHubId, UUID destinationHubId,
             OrderStatus status, Pageable pageable);
 
-    Page<Order> findByOriginHubNameOrDestinationHubName(
-            String originHubName, String destinationHubName,
+    Page<Order> findByOriginHubIdOrDestinationHubId(
+            UUID originHubId, UUID destinationHubId,
             Pageable pageable);
 
 

--- a/order-service/src/main/java/com/sparta/lucky/order/infrastructure/OrderJpaRepository.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/infrastructure/OrderJpaRepository.java
@@ -10,4 +10,23 @@ import java.util.UUID;
 
 public interface OrderJpaRepository extends JpaRepository<Order, UUID> {
     Page<Order> findByStatus(OrderStatus status, Pageable pageable);
+    // 업체 담당자용
+    Page<Order> findByRequesterCompanyIdOrReceiverCompanyIdAndStatus(
+            UUID requesterCompanyId, UUID receiverCompanyId,
+            OrderStatus status, Pageable pageable);
+
+    Page<Order> findByRequesterCompanyIdOrReceiverCompanyId(
+            UUID requesterCompanyId, UUID receiverCompanyId,
+            Pageable pageable);
+
+    // 허브 매니저용
+    Page<Order> findByOriginHubNameOrDestinationHubNameAndStatus(
+            String originHubName, String destinationHubName,
+            OrderStatus status, Pageable pageable);
+
+    Page<Order> findByOriginHubNameOrDestinationHubName(
+            String originHubName, String destinationHubName,
+            Pageable pageable);
+
+
 }

--- a/order-service/src/main/java/com/sparta/lucky/order/infrastructure/OrderJpaRepository.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/infrastructure/OrderJpaRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface OrderJpaRepository extends JpaRepository<Order, UUID> {
@@ -45,4 +46,18 @@ public interface OrderJpaRepository extends JpaRepository<Order, UUID> {
     Page<Order> findByOriginHubIdOrDestinationHubId(
             UUID originHubId, UUID destinationHubId,
             Pageable pageable);
+
+    // 배송 담당자용
+    Page<Order> findByDeliveryIdIn(List<UUID> deliveryIds, Pageable pageable);
+
+    @Query("""
+        SELECT o FROM Order o
+        WHERE o.deliveryId IN :deliveryIds
+        AND o.status = :status
+        """)
+    Page<Order> findByDeliveryIdInAndStatus(
+            @Param("deliveryIds") List<UUID> deliveryIds,
+            @Param("status") OrderStatus status,
+            Pageable pageable);
+
 }

--- a/order-service/src/main/java/com/sparta/lucky/order/infrastructure/OrderJpaRepository.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/infrastructure/OrderJpaRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.UUID;
 
 public interface OrderJpaRepository extends JpaRepository<Order, UUID> {

--- a/order-service/src/main/java/com/sparta/lucky/order/infrastructure/OrderJpaRepository.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/infrastructure/OrderJpaRepository.java
@@ -47,17 +47,27 @@ public interface OrderJpaRepository extends JpaRepository<Order, UUID> {
             UUID originHubId, UUID destinationHubId,
             Pageable pageable);
 
-    // 배송 담당자용
-    Page<Order> findByDeliveryIdIn(List<UUID> deliveryIds, Pageable pageable);
+    @Query("""
+    SELECT o FROM Order o
+    WHERE (o.originHubId = :hubId OR o.destinationHubId = :hubId)
+    AND (o.requesterCompanyId = :companyId OR o.receiverCompanyId = :companyId)
+    """)
+    Page<Order> findByHubAndCompany(
+            @Param("hubId") UUID hubId,
+            @Param("companyId") UUID companyId,
+            Pageable pageable);
 
     @Query("""
-        SELECT o FROM Order o
-        WHERE o.deliveryId IN :deliveryIds
-        AND o.status = :status
-        """)
-    Page<Order> findByDeliveryIdInAndStatus(
-            @Param("deliveryIds") List<UUID> deliveryIds,
+    SELECT o FROM Order o
+    WHERE (o.originHubId = :hubId OR o.destinationHubId = :hubId)
+    AND (o.requesterCompanyId = :companyId OR o.receiverCompanyId = :companyId)
+    AND o.status = :status
+    """)
+    Page<Order> findByHubAndCompanyAndStatus(
+            @Param("hubId") UUID hubId,
+            @Param("companyId") UUID companyId,
             @Param("status") OrderStatus status,
             Pageable pageable);
+
 
 }

--- a/order-service/src/main/java/com/sparta/lucky/order/infrastructure/OrderJpaRepository.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/infrastructure/OrderJpaRepository.java
@@ -5,28 +5,44 @@ import com.sparta.lucky.order.domain.OrderStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.UUID;
 
 public interface OrderJpaRepository extends JpaRepository<Order, UUID> {
+
     Page<Order> findByStatus(OrderStatus status, Pageable pageable);
+
     // 업체 담당자용
+    @Query("""
+            SELECT o FROM Order o
+            WHERE (o.requesterCompanyId = :requesterCompanyId OR o.receiverCompanyId = :receiverCompanyId)
+            AND o.status = :status
+            """)
     Page<Order> findByRequesterCompanyIdOrReceiverCompanyIdAndStatus(
-            UUID requesterCompanyId, UUID receiverCompanyId,
-            OrderStatus status, Pageable pageable);
+            @Param("requesterCompanyId") UUID requesterCompanyId,
+            @Param("receiverCompanyId") UUID receiverCompanyId,
+            @Param("status") OrderStatus status,
+            Pageable pageable);
 
     Page<Order> findByRequesterCompanyIdOrReceiverCompanyId(
             UUID requesterCompanyId, UUID receiverCompanyId,
             Pageable pageable);
 
     // 허브 매니저용
+    @Query("""
+            SELECT o FROM Order o
+            WHERE (o.originHubId = :originHubId OR o.destinationHubId = :destinationHubId)
+            AND o.status = :status
+            """)
     Page<Order> findByOriginHubIdOrDestinationHubIdAndStatus(
-            UUID originHubId, UUID destinationHubId,
-            OrderStatus status, Pageable pageable);
+            @Param("originHubId") UUID originHubId,
+            @Param("destinationHubId") UUID destinationHubId,
+            @Param("status") OrderStatus status,
+            Pageable pageable);
 
     Page<Order> findByOriginHubIdOrDestinationHubId(
             UUID originHubId, UUID destinationHubId,
             Pageable pageable);
-
-
 }

--- a/order-service/src/main/java/com/sparta/lucky/order/infrastructure/OrderRepositoryImpl.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/infrastructure/OrderRepositoryImpl.java
@@ -8,7 +8,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 

--- a/order-service/src/main/java/com/sparta/lucky/order/infrastructure/OrderRepositoryImpl.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/infrastructure/OrderRepositoryImpl.java
@@ -50,15 +50,15 @@ public class OrderRepositoryImpl implements OrderRepository {
     }
 
     @Override
-    public Page<Order> findByOriginHubNameOrDestinationHubName(
-            String originHubName, String destinationHubName,
+    public Page<Order> findByOriginHubIdOrDestinationHubId(
+            UUID originHubId, UUID destinationHubId,
             OrderStatus status, Pageable pageable) {
         if (status != null) {
-            return jpaRepository.findByOriginHubNameOrDestinationHubNameAndStatus(
-                    originHubName, destinationHubName, status, pageable);
+            return jpaRepository.findByOriginHubIdOrDestinationHubIdAndStatus(
+                    originHubId, destinationHubId, status, pageable);
         }
-        return jpaRepository.findByOriginHubNameOrDestinationHubName(
-                originHubName, destinationHubName, pageable);
+        return jpaRepository.findByOriginHubIdOrDestinationHubId(
+                originHubId, destinationHubId, pageable);
     }
 
 }

--- a/order-service/src/main/java/com/sparta/lucky/order/infrastructure/OrderRepositoryImpl.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/infrastructure/OrderRepositoryImpl.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -59,6 +60,16 @@ public class OrderRepositoryImpl implements OrderRepository {
         }
         return jpaRepository.findByOriginHubIdOrDestinationHubId(
                 originHubId, destinationHubId, pageable);
+    }
+
+    @Override
+    public Page<Order> findByDeliveryIdIn(List<UUID> deliveryIds, Pageable pageable) {
+        return jpaRepository.findByDeliveryIdIn(deliveryIds, pageable);
+    }
+
+    @Override
+    public Page<Order> findByDeliveryIdInAndStatus(List<UUID> deliveryIds, OrderStatus status, Pageable pageable) {
+        return jpaRepository.findByDeliveryIdInAndStatus(deliveryIds, status, pageable);
     }
 
 }

--- a/order-service/src/main/java/com/sparta/lucky/order/infrastructure/OrderRepositoryImpl.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/infrastructure/OrderRepositoryImpl.java
@@ -36,4 +36,29 @@ public class OrderRepositoryImpl implements OrderRepository {
     public Page<Order> findByStatus(OrderStatus status, Pageable pageable) {
         return jpaRepository.findByStatus(status, pageable);
     }
+
+    @Override
+    public Page<Order> findByRequesterCompanyIdOrReceiverCompanyId(
+            UUID requesterCompanyId, UUID receiverCompanyId,
+            OrderStatus status, Pageable pageable) {
+        if (status != null) {
+            return jpaRepository.findByRequesterCompanyIdOrReceiverCompanyIdAndStatus(
+                    requesterCompanyId, receiverCompanyId, status, pageable);
+        }
+        return jpaRepository.findByRequesterCompanyIdOrReceiverCompanyId(
+                requesterCompanyId, receiverCompanyId, pageable);
+    }
+
+    @Override
+    public Page<Order> findByOriginHubNameOrDestinationHubName(
+            String originHubName, String destinationHubName,
+            OrderStatus status, Pageable pageable) {
+        if (status != null) {
+            return jpaRepository.findByOriginHubNameOrDestinationHubNameAndStatus(
+                    originHubName, destinationHubName, status, pageable);
+        }
+        return jpaRepository.findByOriginHubNameOrDestinationHubName(
+                originHubName, destinationHubName, pageable);
+    }
+
 }

--- a/order-service/src/main/java/com/sparta/lucky/order/infrastructure/OrderRepositoryImpl.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/infrastructure/OrderRepositoryImpl.java
@@ -63,13 +63,13 @@ public class OrderRepositoryImpl implements OrderRepository {
     }
 
     @Override
-    public Page<Order> findByDeliveryIdIn(List<UUID> deliveryIds, Pageable pageable) {
-        return jpaRepository.findByDeliveryIdIn(deliveryIds, pageable);
+    public Page<Order> findByHubAndCompany(UUID hubId, UUID companyId, OrderStatus status, Pageable pageable) {
+        if (status != null) {
+            return jpaRepository.findByHubAndCompanyAndStatus(hubId, companyId, status, pageable);
+        }
+        return jpaRepository.findByHubAndCompany(hubId, companyId, pageable);
     }
 
-    @Override
-    public Page<Order> findByDeliveryIdInAndStatus(List<UUID> deliveryIds, OrderStatus status, Pageable pageable) {
-        return jpaRepository.findByDeliveryIdInAndStatus(deliveryIds, status, pageable);
-    }
+
 
 }

--- a/order-service/src/main/java/com/sparta/lucky/order/infrastructure/client/DeliveryClient.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/infrastructure/client/DeliveryClient.java
@@ -1,14 +1,13 @@
 package com.sparta.lucky.order.infrastructure.client;
 
 
-import com.sparta.lucky.order.infrastructure.client.dto.FeignApiResponse;
 import com.sparta.lucky.order.infrastructure.client.dto.DeliveryCreateRequest;
 import com.sparta.lucky.order.infrastructure.client.dto.DeliveryCreateResponse;
 import com.sparta.lucky.order.infrastructure.client.dto.DeliveryStatusResponse;
+import com.sparta.lucky.order.infrastructure.client.dto.FeignApiResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.UUID;
 
 @FeignClient(name = "delivery-service")

--- a/order-service/src/main/java/com/sparta/lucky/order/infrastructure/client/DeliveryClient.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/infrastructure/client/DeliveryClient.java
@@ -21,10 +21,10 @@ public interface DeliveryClient {
     FeignApiResponse<DeliveryStatusResponse> getDeliveryStatus(@PathVariable UUID orderId,
 
                                                                @RequestHeader("X-Internal-Request") String internalRequest);
-    // TODO: delivery-service 배송 취소 API 아직은 미구현 상태 -> 구현될시 주석해제
-    // @DeleteMapping("/internal/api/v1/deliveries/{deliveryId}")
-    // FeignApiResponse<Void> cancelDelivery(
-    //         @PathVariable UUID deliveryId,
-    //         @RequestHeader("X-Internal-Request") String internalRequest
-    // );
+
+    @DeleteMapping("/internal/api/v1/deliveries/{deliveryId}")
+    FeignApiResponse<Void> cancelDelivery(
+            @PathVariable UUID deliveryId,
+            @RequestHeader("X-Internal-Request") String internalRequest
+    );
 }

--- a/order-service/src/main/java/com/sparta/lucky/order/infrastructure/client/DeliveryClient.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/infrastructure/client/DeliveryClient.java
@@ -20,11 +20,12 @@ public interface DeliveryClient {
 
     @GetMapping("/internal/api/v1/deliveries/{orderId}/status")
     FeignApiResponse<DeliveryStatusResponse> getDeliveryStatus(@PathVariable UUID orderId,
-                                                               @RequestHeader("X-Internal-Request") String internalRequest);
 
-    @GetMapping("/internal/api/v1/deliveries/driver/{driverId}")
-    FeignApiResponse<List<UUID>> getDeliveryIdsByDriver(
-            @PathVariable UUID driverId,
-            @RequestHeader("X-Internal-Request") String internalRequest
-    );
+                                                               @RequestHeader("X-Internal-Request") String internalRequest);
+    // TODO: delivery-service 배송 취소 API 아직은 미구현 상태 -> 구현될시 주석해제
+    // @DeleteMapping("/internal/api/v1/deliveries/{deliveryId}")
+    // FeignApiResponse<Void> cancelDelivery(
+    //         @PathVariable UUID deliveryId,
+    //         @RequestHeader("X-Internal-Request") String internalRequest
+    // );
 }

--- a/order-service/src/main/java/com/sparta/lucky/order/infrastructure/client/DeliveryClient.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/infrastructure/client/DeliveryClient.java
@@ -8,6 +8,7 @@ import com.sparta.lucky.order.infrastructure.client.dto.DeliveryStatusResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @FeignClient(name = "delivery-service")
@@ -20,4 +21,10 @@ public interface DeliveryClient {
     @GetMapping("/internal/api/v1/deliveries/{orderId}/status")
     FeignApiResponse<DeliveryStatusResponse> getDeliveryStatus(@PathVariable UUID orderId,
                                                                @RequestHeader("X-Internal-Request") String internalRequest);
+
+    @GetMapping("/internal/api/v1/deliveries/driver/{driverId}")
+    FeignApiResponse<List<UUID>> getDeliveryIdsByDriver(
+            @PathVariable UUID driverId,
+            @RequestHeader("X-Internal-Request") String internalRequest
+    );
 }

--- a/order-service/src/main/java/com/sparta/lucky/order/infrastructure/client/dto/DeliveryCreateRequest.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/infrastructure/client/dto/DeliveryCreateRequest.java
@@ -3,7 +3,6 @@ package com.sparta.lucky.order.infrastructure.client.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter

--- a/order-service/src/main/java/com/sparta/lucky/order/infrastructure/client/dto/DeliveryCreateRequest.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/infrastructure/client/dto/DeliveryCreateRequest.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 public class DeliveryCreateRequest {
     private UUID orderId;
     private UUID companyId;
-    private UUID fromHubId;
+    private UUID originHubId;  // from_hub_id → origin_hub_id로 변경
     private String recipientName;
     private String recipientSlackId;
     private LocalDateTime deliveryDueDate;

--- a/order-service/src/main/java/com/sparta/lucky/order/infrastructure/client/dto/DeliveryCreateRequest.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/infrastructure/client/dto/DeliveryCreateRequest.java
@@ -11,8 +11,7 @@ import java.util.UUID;
 public class DeliveryCreateRequest {
     private UUID orderId;
     private UUID companyId;
-    private UUID originHubId;  // from_hub_id → origin_hub_id로 변경
+    private UUID originHubId;
     private String recipientName;
     private String recipientSlackId;
-    private LocalDateTime deliveryDueDate;
 }

--- a/order-service/src/main/java/com/sparta/lucky/order/infrastructure/client/dto/DeliveryCreateResponse.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/infrastructure/client/dto/DeliveryCreateResponse.java
@@ -3,7 +3,6 @@ package com.sparta.lucky.order.infrastructure.client.dto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
 import java.util.UUID;
 
 @Getter

--- a/order-service/src/main/java/com/sparta/lucky/order/infrastructure/client/dto/DeliveryCreateResponse.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/infrastructure/client/dto/DeliveryCreateResponse.java
@@ -10,10 +10,4 @@ import java.util.UUID;
 @NoArgsConstructor
 public class DeliveryCreateResponse {
     private UUID deliveryId;
-
-    // 경로 정보 (hub-service 경로 탐색 결과)
-    private Integer totalDuration;      // 총 소요시간 (분)
-    private Integer totalDistance;      // 총 거리 (km)
-    private List<UUID> route;           // 경유 허브 UUID 목록
-
 }

--- a/order-service/src/main/java/com/sparta/lucky/order/infrastructure/client/dto/UserResponse.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/infrastructure/client/dto/UserResponse.java
@@ -11,4 +11,6 @@ public class UserResponse {
     private UUID userId;
     private String name;
     private String receiverSlackId;
+    private UUID hubId;      // HUB_MANAGER 소속 허브
+    private UUID companyId;  // COMPANY_MANAGER 소속 업체
 }

--- a/order-service/src/main/java/com/sparta/lucky/order/presentation/OrderController.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/presentation/OrderController.java
@@ -46,16 +46,17 @@ public class OrderController {
     public ResponseEntity<ApiResponse<Page<OrderResponse>>> getOrders(
             @RequestParam(required = false) OrderStatus status,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
-            Pageable pageable
+            Pageable pageable,
+            @AuthenticationPrincipal String userId,
+            @RequestHeader(value = "X-User-Role", required = false) String role
     ) {
-        // 허용 페이지 사이즈: 10, 30, 50 — 그 외는 10으로 고정
         int pageSize = pageable.getPageSize();
         if (pageSize != 10 && pageSize != 30 && pageSize != 50) {
-            pageable = PageRequest.of(
-                    pageable.getPageNumber(), 10, pageable.getSort()
-            );
+            pageable = PageRequest.of(pageable.getPageNumber(), 10, pageable.getSort());
         }
-        return ResponseEntity.ok(ApiResponse.success(orderService.getOrders(status, pageable)));
+        UUID userUUID = userId != null ? UUID.fromString(userId) : null;
+        return ResponseEntity.ok(ApiResponse.success(
+                orderService.getOrders(status, role, userUUID, pageable)));
     }
 
     @Operation(summary = "주문 단건 조회")

--- a/order-service/src/main/java/com/sparta/lucky/order/presentation/OrderController.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/presentation/OrderController.java
@@ -35,10 +35,12 @@ public class OrderController {
     @PostMapping
     public ResponseEntity<ApiResponse<OrderResponse>> createOrder(
             @RequestBody @Valid PostOrderReqDto request,
-            @AuthenticationPrincipal String userId
+            @AuthenticationPrincipal String userId,
+            @RequestHeader(value = "X-User-Role", required = false) String role
+
     ) {
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.success(orderService.createOrder(request.toCommand())));
+                .body(ApiResponse.success(orderService.createOrder(request.toCommand(),userId,role)));
     }
 
     @Operation(summary = "주문 목록 조회", description = "status 필터 가능. 페이지 사이즈: 10 / 30 / 50 (그 외는 10으로 고정)")

--- a/order-service/src/main/java/com/sparta/lucky/order/presentation/OrderController.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/presentation/OrderController.java
@@ -17,6 +17,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
@@ -32,7 +34,8 @@ public class OrderController {
     @Operation(summary = "주문 생성")
     @PostMapping
     public ResponseEntity<ApiResponse<OrderResponse>> createOrder(
-            @RequestBody @Valid PostOrderReqDto request
+            @RequestBody @Valid PostOrderReqDto request,
+            @AuthenticationPrincipal String userId
     ) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success(orderService.createOrder(request.toCommand())));
@@ -64,6 +67,7 @@ public class OrderController {
     }
 
     @Operation(summary = "주문 수정", description = "requestNote, requestedDeadline 수정 가능 (CREATED 상태만)")
+    @PreAuthorize("hasAnyRole('MASTER', 'HUB_MANAGER')")
     @PatchMapping("/{id}")
     public ResponseEntity<ApiResponse<OrderResponse>> updateOrder(
             @PathVariable UUID id,
@@ -73,6 +77,7 @@ public class OrderController {
     }
 
     @Operation(summary = "주문 취소", description = "상태를 CANCELLED로 변경 (CREATED 상태만 가능, 노출 유지)")
+    @PreAuthorize("hasAnyRole('MASTER', 'HUB_MANAGER')")
     @PatchMapping("/{id}/cancel")
     public ResponseEntity<ApiResponse<OrderResponse>> cancelOrder(
             @PathVariable UUID id
@@ -80,13 +85,15 @@ public class OrderController {
         return ResponseEntity.ok(ApiResponse.success(orderService.cancelOrder(id)));
     }
 
+
     @Operation(summary = "주문 삭제", description = "Soft delete (CANCELLED / COMPLETED 상태만 가능)")
+    @PreAuthorize("hasRole('MASTER')")
     @DeleteMapping("/{id}")
     public ResponseEntity<ApiResponse<Void>> deleteOrder(
             @PathVariable UUID id,
-            @RequestHeader(value = "X-User-Id") UUID deletedBy
+            @AuthenticationPrincipal String deletedBy
     ) {
-        orderService.deleteOrder(id, deletedBy);
+        orderService.deleteOrder(id, UUID.fromString(deletedBy));
         return ResponseEntity.ok(ApiResponse.success());
     }
 }

--- a/order-service/src/main/java/com/sparta/lucky/order/presentation/OrderController.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/presentation/OrderController.java
@@ -47,6 +47,8 @@ public class OrderController {
     @GetMapping
     public ResponseEntity<ApiResponse<Page<OrderResponse>>> getOrders(
             @RequestParam(required = false) OrderStatus status,
+            @RequestParam(required = false) UUID hubId,
+            @RequestParam(required = false) UUID companyId,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable,
             @AuthenticationPrincipal String userId,
@@ -58,7 +60,7 @@ public class OrderController {
         }
         UUID userUUID = userId != null ? UUID.fromString(userId) : null;
         return ResponseEntity.ok(ApiResponse.success(
-                orderService.getOrders(status, role, userUUID, pageable)));
+                orderService.getOrders(status, role, hubId, companyId, userUUID, pageable)));
     }
 
     @Operation(summary = "주문 단건 조회")

--- a/order-service/src/main/resources/application.yml
+++ b/order-service/src/main/resources/application.yml
@@ -29,6 +29,8 @@ spring:
         jwt:
           issuer-uri: http://lucky-keycloak:8080/realms/lucky
           jwk-set-uri: http://lucky-keycloak:8080/realms/lucky/protocol/openid-connect/certs
+#    internal-request:
+#      secret: ${INTERNAL_REQUEST_SECRET:lucky-internal-secret}
 
 eureka:
   client:


### PR DESCRIPTION
## 📋 관련 이슈
> 관련 이슈 번호를 적어주세요.
- close #71

## 🔧 작업 내용
> 
1. 서비스 간 트랜잭션
주문 생성 시 다음 순서로 외부 서비스를 호출하며, 실패 시 BusinessException을 통해 롤백을 유도합니다.

상품 & 재고: ProductService 상품 정보 조회 및 재고 차감 (선행 조건)
업체 & 허브: 수령 업체 주소 확인 및 출발/도착 허브 확보
사용자: 수령자 정보 및 담당 허브 매니저 슬랙 ID 조회 (알림용 스냅샷 저장)
배송: DeliveryService 배송 생성 요청 및 배송 ID 연동

2. 역할 기반 인가(RBAC) 및 조회 필터링
인가 (@PreAuthorize):
MASTER, HUB_MANAGER: 수정/취소 권한
MASTER: 삭제 권한

필터링 (getOrders):
MASTER: 전체 주문 조회
HUB_MANAGER: 본인 담당 허브(출발/도착) 관련 주문만 노출
COMPANY_MANAGER: 소속 업체 관련 주문만 노출

3. 도메인 보호 및 보안 강화
상태 기반 검증: CANCELLED 또는 COMPLETED 상태에서는 주문 수정/취소 불가 로직 적용 (Domain 내 보호)
내부 호출 보호: 모든 FeignClient 호출 시 X-Internal-Request 헤더를 필수 전송하여 보안을 강화

## ✅ 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [x] 불필요한 주석/코드를 제거했나요?
- [x] 로컬에서 테스트 완료했나요?
- [ ] API 명세서와 일치하나요?

## 📝 리뷰 요청 사항
> 리뷰어가 집중해서 봐줬으면 하는 부분을 적어주세요.
> (없으면 삭제)

## 📷 스크린샷
> API 테스트 결과 등 첨부하면 좋아요.
> (없으면 삭제)




