### PR TITLE
[Feat] notification-service Gateway 연동 보안 필터 적용 및 Security 설정 완료

### DIFF
--- a/notification-service/src/main/java/com/sparta/lucky/notification/common/config/AuditConfig.java
+++ b/notification-service/src/main/java/com/sparta/lucky/notification/common/config/AuditConfig.java
@@ -16,6 +16,9 @@ import java.util.UUID;
 @EnableJpaAuditing
 public class AuditConfig {
 
+    private static final UUID SYSTEM_ID =
+            UUID.fromString("00000000-0000-0000-0000-000000000000");
+
     @Bean
     public AuditorAware<UUID> auditorAware() {
         return () -> {
@@ -23,7 +26,7 @@ public class AuditConfig {
                 // Gateway가 주입한 X-User-Id 헤더에서 현재 요청자 UUID 추출
                 ServletRequestAttributes attrs =
                         (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
-                if (attrs == null) return Optional.empty();
+                if (attrs == null) return Optional.of(SYSTEM_ID);  // ← fallback
 
                 String userId = attrs.getRequest().getHeader("X-User-Id");
                 if (userId == null || userId.isBlank()) return Optional.empty();

--- a/notification-service/src/main/java/com/sparta/lucky/notification/common/config/AuditConfig.java
+++ b/notification-service/src/main/java/com/sparta/lucky/notification/common/config/AuditConfig.java
@@ -23,18 +23,18 @@ public class AuditConfig {
     public AuditorAware<UUID> auditorAware() {
         return () -> {
             try {
-                // Gateway가 주입한 X-User-Id 헤더에서 현재 요청자 UUID 추출
-                ServletRequestAttributes attrs =
-                        (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
-                if (attrs == null) return Optional.of(SYSTEM_ID);  // ← fallback
+                var requestAttributes = RequestContextHolder.getRequestAttributes();
+                if (!(requestAttributes instanceof ServletRequestAttributes attrs)) {
+                    return Optional.of(SYSTEM_ID);  // fallback
+                }
 
                 String userId = attrs.getRequest().getHeader("X-User-Id");
-                if (userId == null || userId.isBlank()) return Optional.empty();
+                if (userId == null || userId.isBlank()) return Optional.of(SYSTEM_ID);
 
                 return Optional.of(UUID.fromString(userId));
             } catch (Exception e) {
                 log.debug("X-User-Id 헤더에서 auditor 정보를 확인할 수 없습니다", e);
-                return Optional.empty();
+                return Optional.of(SYSTEM_ID);
             }
         };
     }

--- a/notification-service/src/main/java/com/sparta/lucky/notification/common/config/SecurityConfig.java
+++ b/notification-service/src/main/java/com/sparta/lucky/notification/common/config/SecurityConfig.java
@@ -1,25 +1,39 @@
 package com.sparta.lucky.notification.common.config;
 
+import com.sparta.lucky.notification.common.filter.HeaderAuthenticationFilter;
+import com.sparta.lucky.notification.common.filter.InternalRequestFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final HeaderAuthenticationFilter headerAuthenticationFilter;
+    private final InternalRequestFilter internalRequestFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/internal/**").permitAll() // 내부 API는 인증 제외
-                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll() // Swagger
+                        .requestMatchers("/internal/**").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated()
                 )
+                .addFilterBefore(headerAuthenticationFilter,
+                        UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(internalRequestFilter,
+                        HeaderAuthenticationFilter.class)
                 .oauth2ResourceServer(oauth -> oauth.jwt(Customizer.withDefaults()));
         return http.build();
     }

--- a/notification-service/src/main/java/com/sparta/lucky/notification/common/config/SwaggerConfig.java
+++ b/notification-service/src/main/java/com/sparta/lucky/notification/common/config/SwaggerConfig.java
@@ -1,7 +1,10 @@
 package com.sparta.lucky.notification.common.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -14,6 +17,12 @@ public class SwaggerConfig {
                 .info(new Info()
                         .title("Notification Service API")
                         .description("알림 서비스 API 문서")
-                        .version("v1.0.0"));
+                        .version("v1.0.0"))
+                .addSecurityItem(new SecurityRequirement().addList("BearerAuth"))
+                .components(new Components()
+                        .addSecuritySchemes("BearerAuth", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
     }
 }

--- a/notification-service/src/main/java/com/sparta/lucky/notification/common/exception/NotificationErrorCode.java
+++ b/notification-service/src/main/java/com/sparta/lucky/notification/common/exception/NotificationErrorCode.java
@@ -14,7 +14,7 @@ public enum NotificationErrorCode implements ErrorCode {
     SLACK_ID_INVALID("NTF_005", "슬랙 ID가 유효하지 않습니다.", 400),
     ORDER_NOT_FOUND("NTF_006", "주문 정보를 찾을 수 없습니다.", 404),
     ORDER_SERVICE_FAILED("NTF_007", "주문 서비스 조회에 실패했습니다.", 500),
-
+    ACCESS_DENIED("NTF_008", "접근 권한이 없습니다.", 403),
     ;
 
     private final String code;

--- a/notification-service/src/main/java/com/sparta/lucky/notification/common/filter/HeaderAuthenticationFilter.java
+++ b/notification-service/src/main/java/com/sparta/lucky/notification/common/filter/HeaderAuthenticationFilter.java
@@ -4,6 +4,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.lang.NonNull;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -17,9 +18,9 @@ import java.util.List;
 public class HeaderAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request,
-                                    HttpServletResponse response,
-                                    FilterChain filterChain) throws ServletException, IOException {
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain) throws ServletException, IOException {
         String userId = request.getHeader("X-User-Id");
         String role = request.getHeader("X-User-Role");
 

--- a/notification-service/src/main/java/com/sparta/lucky/notification/common/filter/HeaderAuthenticationFilter.java
+++ b/notification-service/src/main/java/com/sparta/lucky/notification/common/filter/HeaderAuthenticationFilter.java
@@ -1,0 +1,37 @@
+package com.sparta.lucky.notification.common.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+public class HeaderAuthenticationFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String userId = request.getHeader("X-User-Id");
+        String role = request.getHeader("X-User-Role");
+
+        if (userId != null && !userId.isBlank() && role != null && !role.isBlank()) {
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            userId,
+                            null,
+                            List.of(new SimpleGrantedAuthority("ROLE_" + role))
+                    );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/notification-service/src/main/java/com/sparta/lucky/notification/common/filter/InternalRequestFilter.java
+++ b/notification-service/src/main/java/com/sparta/lucky/notification/common/filter/InternalRequestFilter.java
@@ -1,0 +1,35 @@
+package com.sparta.lucky.notification.common.filter;
+
+import com.sparta.lucky.notification.common.exception.BusinessException;
+import com.sparta.lucky.notification.common.exception.NotificationErrorCode;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class InternalRequestFilter extends OncePerRequestFilter {
+
+    private static final String INTERNAL_PATH_PREFIX = "/internal/";
+    private static final String INTERNAL_HEADER = "X-Internal-Request";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        if (request.getRequestURI().startsWith(INTERNAL_PATH_PREFIX)) {
+            validateInternalRequest(request.getHeader(INTERNAL_HEADER));
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private void validateInternalRequest(String internalRequest) {
+        if (internalRequest == null || internalRequest.isBlank()) {
+            throw new BusinessException(NotificationErrorCode.ACCESS_DENIED);
+        }
+    }
+}

--- a/notification-service/src/main/java/com/sparta/lucky/notification/common/filter/InternalRequestFilter.java
+++ b/notification-service/src/main/java/com/sparta/lucky/notification/common/filter/InternalRequestFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -18,9 +19,9 @@ public class InternalRequestFilter extends OncePerRequestFilter {
     private static final String INTERNAL_HEADER = "X-Internal-Request";
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request,
-                                    HttpServletResponse response,
-                                    FilterChain filterChain) throws ServletException, IOException {
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain) throws ServletException, IOException {
         if (request.getRequestURI().startsWith(INTERNAL_PATH_PREFIX)) {
             validateInternalRequest(request.getHeader(INTERNAL_HEADER));
         }

--- a/notification-service/src/main/java/com/sparta/lucky/notification/common/filter/InternalRequestFilter.java
+++ b/notification-service/src/main/java/com/sparta/lucky/notification/common/filter/InternalRequestFilter.java
@@ -1,11 +1,13 @@
 package com.sparta.lucky.notification.common.filter;
 
-import com.sparta.lucky.notification.common.exception.BusinessException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sparta.lucky.notification.common.exception.NotificationErrorCode;
+import com.sparta.lucky.notification.common.response.ApiResponse;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -13,24 +15,33 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 
 @Component
+@RequiredArgsConstructor
 public class InternalRequestFilter extends OncePerRequestFilter {
 
     private static final String INTERNAL_PATH_PREFIX = "/internal/";
     private static final String INTERNAL_HEADER = "X-Internal-Request";
+    private final ObjectMapper objectMapper;
 
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request,
                                     @NonNull HttpServletResponse response,
                                     @NonNull FilterChain filterChain) throws ServletException, IOException {
         if (request.getRequestURI().startsWith(INTERNAL_PATH_PREFIX)) {
-            validateInternalRequest(request.getHeader(INTERNAL_HEADER));
+            String internalHeader = request.getHeader(INTERNAL_HEADER);
+            if (internalHeader == null || internalHeader.isBlank()) {
+                sendErrorResponse(response);
+                return;
+            }
         }
         filterChain.doFilter(request, response);
     }
 
-    private void validateInternalRequest(String internalRequest) {
-        if (internalRequest == null || internalRequest.isBlank()) {
-            throw new BusinessException(NotificationErrorCode.ACCESS_DENIED);
-        }
+    private void sendErrorResponse(HttpServletResponse response) throws IOException {
+        response.setStatus(NotificationErrorCode.ACCESS_DENIED.getHttpStatus());
+        response.setContentType("application/json;charset=UTF-8");
+        ApiResponse<Void> errorResponse = ApiResponse.error(
+                NotificationErrorCode.ACCESS_DENIED.getCode(),
+                NotificationErrorCode.ACCESS_DENIED.getMessage());
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
     }
 }

--- a/notification-service/src/main/java/com/sparta/lucky/notification/infrastructure/client/dto/OrderResponse.java
+++ b/notification-service/src/main/java/com/sparta/lucky/notification/infrastructure/client/dto/OrderResponse.java
@@ -1,5 +1,6 @@
 package com.sparta.lucky.notification.infrastructure.client.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,6 +9,7 @@ import java.util.UUID;
 
 @Getter
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class OrderResponse {
 
     private UUID id;


### PR DESCRIPTION
## 📋 관련 이슈
> 관련 이슈 번호를 적어주세요.
- close #77

## 🔧 작업 내용
> notification-service가 전체 시스템의 인증 체계(Keycloak + Gateway) 내에서 안전하게 동작할 수 있도록 보안 레이어를 구현

**인증 필터 (HeaderAuthenticationFilter)**
- Gateway에서 추출한 유저 정보를 기반으로 SecurityContextHolder 
- ROLE_ 접두사를 자동으로 부여하여 컨트롤러 내 @PreAuthorize 권한 체크 -> 아직 컨트롤러에서 역할분기는 하지않음

**내부 호출 보호 (InternalRequestFilter)**
- /internal/으로 시작하는 모든 요청에 대해 X-Internal-Request 헤더 존재 여부를 체크
- 헤더가 없을 경우 403 Forbidden 에러를 반환하여 직접 호출(Backdoor)을 차단

**Security 설정 및 OAuth2 연동**
- application.yml에 도커 환경용 Keycloak issuer-uri와 jwk-set-uri를 설정
- Swagger UI 및 내부 경로에 대한 접근 허용 규칙

## ✅ 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [x] 불필요한 주석/코드를 제거했나요?
- [x] 로컬에서 테스트 완료했나요?
- [ ] API 명세서와 일치하나요?

## 📝 리뷰 요청 사항
> 리뷰어가 집중해서 봐줬으면 하는 부분을 적어주세요.
> (없으면 삭제)

## 📷 스크린샷
> API 테스트 결과 등 첨부하면 좋아요.
> (없으면 삭제)




