### PR TITLE
[fix] path 응답 구조 수정 (route 별 expectedDuration, expectedDistance 추가)

### DIFF
--- a/hub-service/src/main/java/com/sparta/lucky/hub/application/HubPathService.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/application/HubPathService.java
@@ -1,6 +1,7 @@
 package com.sparta.lucky.hub.application;
 
 import com.sparta.lucky.hub.application.dto.GetRouteResult;
+import com.sparta.lucky.hub.application.dto.GetRouteResult.RouteSegment;
 import com.sparta.lucky.hub.common.exception.BusinessException;
 import com.sparta.lucky.hub.common.exception.HubErrorCode;
 import com.sparta.lucky.hub.domain.HubRoute;
@@ -17,24 +18,24 @@ public class HubPathService {
 
     private final HubRouteService hubRouteService;
 
-    @Cacheable(cacheNames = "path", key = "#originHubId + '-' + #destinationHubId")
+    //@Cacheable(cacheNames = "path", key = "#originHubId + '-' + #destinationHubId")
     @Transactional(readOnly = true)
     public GetRouteResult getRoute(UUID originHubId, UUID destinationHubId) {
 
         // 출발 허브 == 도착 허브인 경우
         if (originHubId.equals(destinationHubId)) {
-            return GetRouteResult.of(originHubId, destinationHubId, 0, 0, List.of(originHubId));
+            return GetRouteResult.of(originHubId, destinationHubId, 0, 0, List.of());
         }
 
         // Dijkstra로 최단 경로 탐색 (캐시 경유)
         List<HubRoute> routes = hubRouteService.getHubRoutes();
         PathResult result = findShortestPath(routes, originHubId, destinationHubId);
 
-        return GetRouteResult.of(originHubId, destinationHubId, result.totalDuration(), result.totalDistance(), result.path());
+        return GetRouteResult.of(originHubId, destinationHubId, result.totalDuration(), result.totalDistance(), result.route());
     }
 
 
-    private record PathResult(List<UUID> path, int totalDistance, int totalDuration) {}
+    private record PathResult(List<RouteSegment> route, int totalDistance, int totalDuration) {}
 
     // 시작 Hub에서 도착 Hub 최단거리 찾기
     private PathResult findShortestPath(List<HubRoute> routes, UUID originId, UUID destinationId) {
@@ -47,7 +48,7 @@ public class HubPathService {
 
         Map<UUID, Integer> distMap = new HashMap<>();
         Map<UUID, Integer> duraMap = new HashMap<>();
-        Map<UUID, UUID> prev = new HashMap<>();
+        Map<UUID, HubRoute> prevEdge = new HashMap<>();
         PriorityQueue<UUID> pq = new PriorityQueue<>(
                 Comparator.comparingInt(id -> distMap.getOrDefault(id, Integer.MAX_VALUE))
         );
@@ -70,7 +71,7 @@ public class HubPathService {
                 if (newDist < distMap.getOrDefault(next, Integer.MAX_VALUE)) {
                     distMap.put(next, newDist);
                     duraMap.put(next, duraMap.getOrDefault(cur, 0) + edge.getDuration());
-                    prev.put(next, cur);
+                    prevEdge.put(next, edge);
                     pq.offer(next);
                 }
             }
@@ -81,25 +82,31 @@ public class HubPathService {
         }
 
         return new PathResult(
-                reconstructPath(prev, originId, destinationId),
+                reconstructPath(prevEdge, originId, destinationId),
                 distMap.get(destinationId),
                 duraMap.get(destinationId)
         );
     }
 
-    private List<UUID> reconstructPath(Map<UUID, UUID> prev, UUID originId, UUID destinationId) {
-        LinkedList<UUID> path = new LinkedList<>();
+    private List<RouteSegment> reconstructPath(Map<UUID, HubRoute> prevEdge, UUID originId, UUID destinationId) {
+        LinkedList<RouteSegment> segments = new LinkedList<>();
         UUID cur = destinationId;
 
-        while (cur != null) {
-            path.addFirst(cur);
-            cur = prev.get(cur);
+        while (prevEdge.containsKey(cur)) {
+            HubRoute edge = prevEdge.get(cur);
+            segments.addFirst(new RouteSegment(
+                    edge.getOriginHubId(),
+                    edge.getDestinationHubId(),
+                    edge.getDuration(),
+                    edge.getDistance()
+            ));
+            cur = edge.getOriginHubId();
         }
 
-        if (path.isEmpty() || !path.getFirst().equals(originId)) {
+        if (!cur.equals(originId)) {
             throw new BusinessException(HubErrorCode.HUB_ROUTE_NOT_FOUND);
         }
 
-        return Collections.unmodifiableList(path);
+        return Collections.unmodifiableList(segments);
     }
 }

--- a/hub-service/src/main/java/com/sparta/lucky/hub/application/dto/GetRouteResult.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/application/dto/GetRouteResult.java
@@ -14,7 +14,14 @@ public class GetRouteResult {
     private final UUID destinationHubId;
     private final Integer totalDuration;
     private final Integer totalDistance;
-    private final List<UUID> route;
+    private final List<RouteSegment> route;
+
+    public record RouteSegment(
+            @JsonProperty("fromHubId") UUID fromHubId,
+            @JsonProperty("toHubId") UUID toHubId,
+            @JsonProperty("expectedDuration") Integer expectedDuration,
+            @JsonProperty("expectedDistance") Integer expectedDistance
+    ) {}
 
     @JsonCreator
     private GetRouteResult(
@@ -22,7 +29,7 @@ public class GetRouteResult {
             @JsonProperty("destinationHubId") UUID destinationHubId,
             @JsonProperty("totalDuration") Integer totalDuration,
             @JsonProperty("totalDistance") Integer totalDistance,
-            @JsonProperty("route") List<UUID> route
+            @JsonProperty("route") List<RouteSegment> route
     ) {
         this.originHubId = originHubId;
         this.destinationHubId = destinationHubId;
@@ -31,7 +38,7 @@ public class GetRouteResult {
         this.route = route;
     }
 
-    public static GetRouteResult of(UUID originHubId, UUID destinationHubId, Integer totalDuration, Integer totalDistance, List<UUID> route) {
+    public static GetRouteResult of(UUID originHubId, UUID destinationHubId, Integer totalDuration, Integer totalDistance, List<RouteSegment> route) {
         return new GetRouteResult(originHubId, destinationHubId, totalDuration, totalDistance, route);
     }
 }

--- a/hub-service/src/main/java/com/sparta/lucky/hub/presentation/dto/GetRouteResDto.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/presentation/dto/GetRouteResDto.java
@@ -1,6 +1,7 @@
 package com.sparta.lucky.hub.presentation.dto;
 
 import com.sparta.lucky.hub.application.dto.GetRouteResult;
+import com.sparta.lucky.hub.application.dto.GetRouteResult.RouteSegment;
 import lombok.Getter;
 
 import java.util.List;
@@ -13,7 +14,7 @@ public class GetRouteResDto {
     private final UUID destinationHubId;
     private final Integer totalDuration;
     private final Integer totalDistance;
-    private final List<UUID> route;
+    private final List<RouteSegment> route;
 
     private GetRouteResDto(GetRouteResult result) {
         this.originHubId = result.getOriginHubId();


### PR DESCRIPTION
## 📋 관련 이슈
> 관련 이슈 번호를 적어주세요.
- close #

## 🔧 작업 내용
### path 응답 구조 수정 (경로 별 expectedDuration, expectedDistance 추가)

요청해주신대로 `GET /internal/api/v1/paths?originHubId={originHubId}&destinationHubId={destinationHubId}` 응답을 수정했습니다.

기존 응답
```
 {
      "id": "route_uuid",
      "originHubId": "hub_uuid",
      "destinationHubId": "hub_uuid",
      "totalDuration": 120, //초 단위
      "totalDistance": 85, // m 단위
      "route": ["hub_uuid", "hub_uuid", "hub_uuid"]
  }
```

수정 후 응답
```
 {
      "id": "route_uuid",
      "originHubId": "hub_uuid",
      "destinationHubId": "hub_uuid",
      "totalDuration": 120, //초 단위
      "totalDistance": 85, // m 단위
      "route" : [
        {
            "fromHubId":
            "toHubId":
            "expectedDuration":
            "expectedDistance":
        }, ...
    ]
  }
```

## ✅ 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [ ] 불필요한 주석/코드를 제거했나요?
- [x] 로컬에서 테스트 완료했나요?
- [x] API 명세서와 일치하나요?

## 📝 리뷰 요청 사항
- path 캐싱은 고민해보고, 월요일에 수정하겠습니다 (현재 주석)

## 📷 스크린샷

<img width="1391" height="486" alt="스크린샷 2026-04-05 21 12 33" src="https://github.com/user-attachments/assets/6a8e6333-f55f-470e-91ea-984d3518f700" />

