### PR TITLE
[fix] path 경로 Response 수정에 따른 캐싱 수정

### DIFF
--- a/hub-service/src/main/java/com/sparta/lucky/hub/application/HubPathCacheService.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/application/HubPathCacheService.java
@@ -21,7 +21,7 @@ public class HubPathCacheService {
      * 예: 서울 → 대전 → 부산 이면 [서울UUID, 대전UUID, 부산UUID]
      * 시간/거리는 포함하지 않아 routes 캐시의 최신값을 항상 반영 가능.
      */
-    @Cacheable(cacheNames = "path", key = "#originHubId + '-' + #destinationHubId")
+    @Cacheable(cacheNames = "path", key = "#originHubId + '-' + #destinationHubId", sync = true)
     @Transactional(readOnly = true)
     public List<UUID> getPathHubIds(UUID originHubId, UUID destinationHubId) {
         List<HubRoute> routes = hubRouteService.getHubRoutes();

--- a/hub-service/src/main/java/com/sparta/lucky/hub/application/HubPathCacheService.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/application/HubPathCacheService.java
@@ -1,0 +1,85 @@
+package com.sparta.lucky.hub.application;
+
+import com.sparta.lucky.hub.common.exception.BusinessException;
+import com.sparta.lucky.hub.common.exception.HubErrorCode;
+import com.sparta.lucky.hub.domain.HubRoute;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class HubPathCacheService {
+
+    private final HubRouteService hubRouteService;
+
+    /**
+     * 다익스트라로 구한 최단 경로를 허브 ID 순서 목록으로 캐싱.
+     * 예: 서울 → 대전 → 부산 이면 [서울UUID, 대전UUID, 부산UUID]
+     * 시간/거리는 포함하지 않아 routes 캐시의 최신값을 항상 반영 가능.
+     */
+    @Cacheable(cacheNames = "path", key = "#originHubId + '-' + #destinationHubId")
+    @Transactional(readOnly = true)
+    public List<UUID> getPathHubIds(UUID originHubId, UUID destinationHubId) {
+        List<HubRoute> routes = hubRouteService.getHubRoutes();
+        return findShortestPathHubIds(routes, originHubId, destinationHubId);
+    }
+
+    private List<UUID> findShortestPathHubIds(List<HubRoute> routes, UUID originId, UUID destinationId) {
+        Map<UUID, List<HubRoute>> graph = new HashMap<>();
+        for (HubRoute route : routes) {
+            graph.computeIfAbsent(route.getOriginHubId(), k -> new ArrayList<>()).add(route);
+            graph.computeIfAbsent(route.getDestinationHubId(), k -> new ArrayList<>()).add(route.reverse());
+        }
+
+        Map<UUID, Integer> distMap = new HashMap<>();
+        Map<UUID, UUID> prevHub = new HashMap<>();
+        PriorityQueue<UUID> pq = new PriorityQueue<>(
+                Comparator.comparingInt(id -> distMap.getOrDefault(id, Integer.MAX_VALUE))
+        );
+
+        distMap.put(originId, 0);
+        pq.offer(originId);
+
+        while (!pq.isEmpty()) {
+            UUID cur = pq.poll();
+            if (cur.equals(destinationId)) break;
+
+            int currentDist = distMap.getOrDefault(cur, Integer.MAX_VALUE);
+            for (HubRoute edge : graph.getOrDefault(cur, List.of())) {
+                UUID next = edge.getDestinationHubId();
+                int newDist = currentDist + edge.getDistance();
+                if (newDist < distMap.getOrDefault(next, Integer.MAX_VALUE)) {
+                    distMap.put(next, newDist);
+                    prevHub.put(next, cur);
+                    pq.offer(next);
+                }
+            }
+        }
+
+        if (!distMap.containsKey(destinationId)) {
+            throw new BusinessException(HubErrorCode.HUB_ROUTE_NOT_FOUND);
+        }
+
+        return reconstructHubIds(prevHub, originId, destinationId);
+    }
+
+    private List<UUID> reconstructHubIds(Map<UUID, UUID> prevHub, UUID originId, UUID destinationId) {
+        LinkedList<UUID> hubIds = new LinkedList<>();
+        UUID cur = destinationId;
+
+        while (cur != null) {
+            hubIds.addFirst(cur);
+            cur = prevHub.get(cur);
+        }
+
+        if (!hubIds.getFirst().equals(originId)) {
+            throw new BusinessException(HubErrorCode.HUB_ROUTE_NOT_FOUND);
+        }
+
+        return Collections.unmodifiableList(hubIds);
+    }
+}

--- a/hub-service/src/main/java/com/sparta/lucky/hub/application/HubPathService.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/application/HubPathService.java
@@ -6,19 +6,22 @@ import com.sparta.lucky.hub.common.exception.BusinessException;
 import com.sparta.lucky.hub.common.exception.HubErrorCode;
 import com.sparta.lucky.hub.domain.HubRoute;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class HubPathService {
 
     private final HubRouteService hubRouteService;
+    private final HubPathCacheService hubPathCacheService;
 
-    //@Cacheable(cacheNames = "path", key = "#originHubId + '-' + #destinationHubId")
     @Transactional(readOnly = true)
     public GetRouteResult getRoute(UUID originHubId, UUID destinationHubId) {
 
@@ -27,86 +30,43 @@ public class HubPathService {
             return GetRouteResult.of(originHubId, destinationHubId, 0, 0, List.of());
         }
 
-        // Dijkstra로 최단 경로 탐색 (캐시 경유)
-        List<HubRoute> routes = hubRouteService.getHubRoutes();
-        PathResult result = findShortestPath(routes, originHubId, destinationHubId);
+        // 1) path 캐시: [서울, 대전, 부산, ...] 순서의 허브 ID 목록
+        List<UUID> hubIds = hubPathCacheService.getPathHubIds(originHubId, destinationHubId);
 
-        return GetRouteResult.of(originHubId, destinationHubId, result.totalDuration(), result.totalDistance(), result.route());
-    }
+        // 2) routes 캐시: 현재 시간/거리 정보를 갖는 전체 노선 (양방향 조회용 맵)
+        Map<String, HubRoute> routeMap = buildRouteMap(hubRouteService.getHubRoutes());
 
+        // 3) 연속된 허브 쌍으로 RouteSegment 조립: (서울→대전), (대전→부산), ...
+        List<RouteSegment> segments = new ArrayList<>();
+        int totalDuration = 0;
+        int totalDistance = 0;
 
-    private record PathResult(List<RouteSegment> route, int totalDistance, int totalDuration) {}
-
-    // 시작 Hub에서 도착 Hub 최단거리 찾기
-    private PathResult findShortestPath(List<HubRoute> routes, UUID originId, UUID destinationId) {
-        // 양방향 그래프 구성: 두 허브 간 연결은 양방향으로 취급
-        Map<UUID, List<HubRoute>> graph = new HashMap<>();
-        for (HubRoute route : routes) {
-            graph.computeIfAbsent(route.getOriginHubId(), k -> new ArrayList<>()).add(route);
-            graph.computeIfAbsent(route.getDestinationHubId(), k -> new ArrayList<>()).add(route.reverse());
-        }
-
-        Map<UUID, Integer> distMap = new HashMap<>();
-        Map<UUID, Integer> duraMap = new HashMap<>();
-        Map<UUID, HubRoute> prevEdge = new HashMap<>();
-        PriorityQueue<UUID> pq = new PriorityQueue<>(
-                Comparator.comparingInt(id -> distMap.getOrDefault(id, Integer.MAX_VALUE))
-        );
-
-        distMap.put(originId, 0);
-        duraMap.put(originId, 0);
-        pq.offer(originId);
-
-        while (!pq.isEmpty()) {
-            UUID cur = pq.poll();
-
-            if (cur.equals(destinationId)) break;
-
-            int currentDist = distMap.getOrDefault(cur, Integer.MAX_VALUE);
-
-            for (HubRoute edge : graph.getOrDefault(cur, List.of())) {
-                UUID next = edge.getDestinationHubId();
-                int newDist = currentDist + edge.getDistance();
-
-                if (newDist < distMap.getOrDefault(next, Integer.MAX_VALUE)) {
-                    distMap.put(next, newDist);
-                    duraMap.put(next, duraMap.getOrDefault(cur, 0) + edge.getDuration());
-                    prevEdge.put(next, edge);
-                    pq.offer(next);
-                }
+        for (int i = 0; i < hubIds.size() - 1; i++) {
+            UUID from = hubIds.get(i);
+            UUID to = hubIds.get(i + 1);
+            HubRoute route = routeMap.get(routeKey(from, to));
+            if (route == null) {
+                throw new BusinessException(HubErrorCode.HUB_ROUTE_NOT_FOUND);
             }
+            segments.add(new RouteSegment(from, to, route.getDuration(), route.getDistance()));
+            totalDuration += route.getDuration();
+            totalDistance += route.getDistance();
         }
 
-        if (!distMap.containsKey(destinationId)) {
-            throw new BusinessException(HubErrorCode.HUB_ROUTE_NOT_FOUND);
-        }
-
-        return new PathResult(
-                reconstructPath(prevEdge, originId, destinationId),
-                distMap.get(destinationId),
-                duraMap.get(destinationId)
-        );
+        return GetRouteResult.of(originHubId, destinationHubId, totalDuration, totalDistance, segments);
     }
 
-    private List<RouteSegment> reconstructPath(Map<UUID, HubRoute> prevEdge, UUID originId, UUID destinationId) {
-        LinkedList<RouteSegment> segments = new LinkedList<>();
-        UUID cur = destinationId;
-
-        while (prevEdge.containsKey(cur)) {
-            HubRoute edge = prevEdge.get(cur);
-            segments.addFirst(new RouteSegment(
-                    edge.getOriginHubId(),
-                    edge.getDestinationHubId(),
-                    edge.getDuration(),
-                    edge.getDistance()
-            ));
-            cur = edge.getOriginHubId();
+    /** 양방향 조회를 위해 A→B, B→A 모두 등록 */
+    private Map<String, HubRoute> buildRouteMap(List<HubRoute> routes) {
+        Map<String, HubRoute> map = new HashMap<>(routes.size() * 2);
+        for (HubRoute route : routes) {
+            map.put(routeKey(route.getOriginHubId(), route.getDestinationHubId()), route);
+            map.put(routeKey(route.getDestinationHubId(), route.getOriginHubId()), route);
         }
+        return map;
+    }
 
-        if (!cur.equals(originId)) {
-            throw new BusinessException(HubErrorCode.HUB_ROUTE_NOT_FOUND);
-        }
-
-        return Collections.unmodifiableList(segments);
+    private String routeKey(UUID from, UUID to) {
+        return from + "-" + to;
     }
 }

--- a/hub-service/src/main/java/com/sparta/lucky/hub/application/HubRouteService.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/application/HubRouteService.java
@@ -21,7 +21,7 @@ public class HubRouteService {
     private final HubService hubService;
     private final HubRouteRepository hubRouteRepository;
 
-    @Cacheable(cacheNames = "routes", key = "'all'")
+    @Cacheable(cacheNames = "routes", key = "'all'", sync = true)
     @Transactional(readOnly = true)
     public List<HubRoute> getHubRoutes() {
         return hubRouteRepository.findAllByDeletedAtIsNull();

--- a/hub-service/src/main/java/com/sparta/lucky/hub/application/HubService.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/application/HubService.java
@@ -33,7 +33,7 @@ public class HubService {
         return CreateHubResult.from(hubRepository.save(hub));
     }
 
-    @Cacheable(cacheNames = "hub", key = "#hubId")
+    @Cacheable(cacheNames = "hub", key = "#hubId", sync = true)
     @Transactional(readOnly = true)
     public GetHubResult getHub(UUID hubId) {
         Hub hub = findActiveHub(hubId);
@@ -53,7 +53,7 @@ public class HubService {
                 .map(GetHubResult::from);
     }
 
-    @Cacheable(cacheNames = "hubs", key = "'all'")
+    @Cacheable(cacheNames = "hubs", key = "'all'", sync = true)
     @Transactional(readOnly = true)
     public List<GetHubResult> getHubs() {
         return hubRepository.findAllByDeletedAtIsNull().stream()

--- a/hub-service/src/main/java/com/sparta/lucky/hub/common/config/CacheConfig.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/common/config/CacheConfig.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.sparta.lucky.hub.application.dto.GetHubResult;
-import com.sparta.lucky.hub.application.dto.GetRouteResult;
 import com.sparta.lucky.hub.domain.HubRoute;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -18,6 +17,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.UUID;
 
 @Configuration
 public class CacheConfig {
@@ -59,12 +59,14 @@ public class CacheConfig {
                         new Jackson2JsonRedisSerializer<>(objectMapper, routesType)
                 ));
 
-        // path 캐시: path 단건 (origin-destination 쌍)
+        // path 캐시: List<UUID> (origin-destination 쌍에 대한 경로 허브 ID 순서 목록)
+        JavaType pathType = objectMapper.getTypeFactory()
+                .constructCollectionType(List.class, UUID.class);
         RedisCacheConfiguration routeResultConfig = RedisCacheConfiguration.defaultCacheConfig()
                 .entryTtl(Duration.ofMinutes(30))
                 .serializeKeysWith(keySerializer)
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
-                        new Jackson2JsonRedisSerializer<>(objectMapper, GetRouteResult.class)
+                        new Jackson2JsonRedisSerializer<>(objectMapper, pathType)
                 ));
 
         return RedisCacheManager.builder(connectionFactory)

--- a/hub-service/src/main/java/com/sparta/lucky/hub/domain/HubRoute.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/domain/HubRoute.java
@@ -3,6 +3,7 @@ package com.sparta.lucky.hub.domain;
 import com.sparta.lucky.hub.common.entity.BaseEntity;
 import com.sparta.lucky.hub.common.exception.BusinessException;
 import com.sparta.lucky.hub.common.exception.HubErrorCode;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -15,6 +16,7 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "p_hub_route", schema = "hub_schema")
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class HubRoute extends BaseEntity {
 
     @Id


### PR DESCRIPTION
## 📋 관련 이슈
> 관련 이슈 번호를 적어주세요.
- close #

## 🔧 작업 내용

path 경로 캐싱 형태를 아래와 같이 수정하였습니다.
```
path::e7c393a1-4b29-45e5-8db2-4111cc1f43fe-033557f6-5c93-4762-8773-6640e52175fc

["e7c393a1-4b29-45e5-8db2-4111cc1f43fe","7687af9f-7b02-4564-bba1-15d2818f06c8","70ab8734-d178-4729-b7ba-745e1db47f21","033557f6-5c93-4762-8773-6640e52175fc"]
```

## ✅ 체크리스트
- [ ] 코드 컨벤션을 지켰나요?
- [ ] 불필요한 주석/코드를 제거했나요?
- [ ] 로컬에서 테스트 완료했나요?
- [ ] API 명세서와 일치하나요?




