### PR TITLE
[feat] order/notification Gateway 연동 및 인증 흐름 개선

### DIFF
--- a/api-gateway/src/main/java/com/sparta/lucky/gateway/filter/JwtAuthenticationFilter.java
+++ b/api-gateway/src/main/java/com/sparta/lucky/gateway/filter/JwtAuthenticationFilter.java
@@ -43,7 +43,8 @@ public class JwtAuthenticationFilter extends AbstractGatewayFilterFactory<JwtAut
         return path.startsWith("/api/v1/auth/login") ||
                 path.startsWith("/api/v1/auth/signup") ||
                 path.startsWith("/swagger-ui") ||
-                path.startsWith("/v3/api-docs");
+                path.startsWith("/v3/api-docs") ||
+                path.startsWith("/internal/");
     }
 
     // 토큰 추출 로직 , "Bearer " 뒷부분의 문자열만 추출

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,9 +42,13 @@ services:
     environment:
       KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN}
       KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
+      KC_HOSTNAME_STRICT: "false"
+      KC_HOSTNAME_STRICT_HTTPS: "false" # 실제 서버 운영시에는 true
+      KC_HTTP_ENABLED: "true"
     command: start-dev --import-realm
     volumes:
-      - ./keycloak/realm-export.json:/opt/keycloak/data/import/realm.json # ✅ 설정 파일 연결
+      - ./keycloak/realm-export-2.json:/opt/keycloak/data/import/realm.json
+      - keycloak_data:/opt/keycloak/data # user 데이터 저장
     ports:
       - "9090:8080" #(접속할 때 http://localhost:9090 사용)
     networks:
@@ -218,3 +222,4 @@ networks:
 
 volumes:
   postgres_data:
+  keycloak_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,9 @@ services:
     environment:
       KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN}
       KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
-    command: start-dev
+    command: start-dev --import-realm
+    volumes:
+      - ./keycloak/realm-export.json:/opt/keycloak/data/import/realm.json # ✅ 설정 파일 연결
     ports:
       - "9090:8080" #(접속할 때 http://localhost:9090 사용)
     networks:

--- a/keycloak/realm-export-2.json
+++ b/keycloak/realm-export-2.json
@@ -1,0 +1,2263 @@
+{
+  "id": "858285af-3491-4c05-af4f-a4a97844b5d4",
+  "realm": "lucky",
+  "displayName": "",
+  "displayNameHtml": "",
+  "notBefore": 0,
+  "defaultSignatureAlgorithm": "RS256",
+  "revokeRefreshToken": false,
+  "refreshTokenMaxReuse": 0,
+  "accessTokenLifespan": 1800,
+  "accessTokenLifespanForImplicitFlow": 900,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "ssoSessionIdleTimeoutRememberMe": 0,
+  "ssoSessionMaxLifespanRememberMe": 0,
+  "offlineSessionIdleTimeout": 2592000,
+  "offlineSessionMaxLifespanEnabled": false,
+  "offlineSessionMaxLifespan": 5184000,
+  "clientSessionIdleTimeout": 0,
+  "clientSessionMaxLifespan": 0,
+  "clientOfflineSessionIdleTimeout": 0,
+  "clientOfflineSessionMaxLifespan": 0,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "accessCodeLifespanLogin": 1800,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "oauth2DeviceCodeLifespan": 600,
+  "oauth2DevicePollingInterval": 5,
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "registrationEmailAsUsername": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": false,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "permanentLockout": false,
+  "maxTemporaryLockouts": 0,
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 30,
+  "roles": {
+    "realm": [
+      {
+        "id": "baa43b57-654c-4f1d-a701-85fcbd22d673",
+        "name": "COMPANY_MANAGER",
+        "description": "",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "858285af-3491-4c05-af4f-a4a97844b5d4",
+        "attributes": {}
+      },
+      {
+        "id": "fcd99223-6ba7-46b9-a538-1d8943c57de3",
+        "name": "offline_access",
+        "description": "${role_offline-access}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "858285af-3491-4c05-af4f-a4a97844b5d4",
+        "attributes": {}
+      },
+      {
+        "id": "47eec32d-d66c-45d3-92e9-7a91a606dedf",
+        "name": "DELIVERY_DRIVER",
+        "description": "",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "858285af-3491-4c05-af4f-a4a97844b5d4",
+        "attributes": {}
+      },
+      {
+        "id": "e5824050-7c6a-41f4-9a2e-c3dfd0e8b826",
+        "name": "MASTER",
+        "description": "",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "858285af-3491-4c05-af4f-a4a97844b5d4",
+        "attributes": {}
+      },
+      {
+        "id": "ecd42945-dbf7-44f1-a3ea-3ae217565932",
+        "name": "HUB_MANAGER",
+        "description": "",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "858285af-3491-4c05-af4f-a4a97844b5d4",
+        "attributes": {}
+      },
+      {
+        "id": "eddf3a53-0ecf-40f3-a043-e293720ec174",
+        "name": "default-roles-lucky-logistics",
+        "description": "${role_default-roles}",
+        "composite": true,
+        "composites": {
+          "realm": [
+            "offline_access",
+            "uma_authorization"
+          ],
+          "client": {
+            "account": [
+              "view-profile",
+              "manage-account"
+            ]
+          }
+        },
+        "clientRole": false,
+        "containerId": "858285af-3491-4c05-af4f-a4a97844b5d4",
+        "attributes": {}
+      },
+      {
+        "id": "c2f8b1bd-e96e-4fa9-8783-9836363d18cb",
+        "name": "uma_authorization",
+        "description": "${role_uma_authorization}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "858285af-3491-4c05-af4f-a4a97844b5d4",
+        "attributes": {}
+      }
+    ],
+    "client": {
+      "lucky-client": [],
+      "realm-management": [
+        {
+          "id": "4c642c0c-ccc9-4205-93bc-5d83317123ab",
+          "name": "view-users",
+          "description": "${role_view-users}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-groups",
+                "query-users"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "2800c6a1-ed8a-4c1a-b0d7-c3c24b56c59e",
+          "attributes": {}
+        },
+        {
+          "id": "87eb9e2d-f4f3-46ea-81f9-8680ff9bf23b",
+          "name": "manage-clients",
+          "description": "${role_manage-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2800c6a1-ed8a-4c1a-b0d7-c3c24b56c59e",
+          "attributes": {}
+        },
+        {
+          "id": "d87d8250-8249-4f45-8e69-217fd023baa1",
+          "name": "manage-identity-providers",
+          "description": "${role_manage-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2800c6a1-ed8a-4c1a-b0d7-c3c24b56c59e",
+          "attributes": {}
+        },
+        {
+          "id": "da5606c3-3990-4b95-b32a-eb6674d576b6",
+          "name": "query-users",
+          "description": "${role_query-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2800c6a1-ed8a-4c1a-b0d7-c3c24b56c59e",
+          "attributes": {}
+        },
+        {
+          "id": "35987cfb-f3e2-48d5-b79a-cc2db792f0f9",
+          "name": "query-clients",
+          "description": "${role_query-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2800c6a1-ed8a-4c1a-b0d7-c3c24b56c59e",
+          "attributes": {}
+        },
+        {
+          "id": "b76c28b4-c7a0-4f32-a533-2d7da9a0b6ec",
+          "name": "view-authorization",
+          "description": "${role_view-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2800c6a1-ed8a-4c1a-b0d7-c3c24b56c59e",
+          "attributes": {}
+        },
+        {
+          "id": "6c73ec6b-af60-405d-b4b0-9ec0966651ec",
+          "name": "manage-users",
+          "description": "${role_manage-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2800c6a1-ed8a-4c1a-b0d7-c3c24b56c59e",
+          "attributes": {}
+        },
+        {
+          "id": "16318952-d013-433b-abfb-5e4d375c64a6",
+          "name": "view-events",
+          "description": "${role_view-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2800c6a1-ed8a-4c1a-b0d7-c3c24b56c59e",
+          "attributes": {}
+        },
+        {
+          "id": "7ae14d4a-2d99-4c1b-bec9-bd5b7e3a8e97",
+          "name": "view-identity-providers",
+          "description": "${role_view-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2800c6a1-ed8a-4c1a-b0d7-c3c24b56c59e",
+          "attributes": {}
+        },
+        {
+          "id": "abb7b3f5-3e63-46a9-8476-f72bbb924695",
+          "name": "impersonation",
+          "description": "${role_impersonation}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2800c6a1-ed8a-4c1a-b0d7-c3c24b56c59e",
+          "attributes": {}
+        },
+        {
+          "id": "c6fd9cfa-82a4-4684-b5d2-ff5cd00cec7b",
+          "name": "manage-authorization",
+          "description": "${role_manage-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2800c6a1-ed8a-4c1a-b0d7-c3c24b56c59e",
+          "attributes": {}
+        },
+        {
+          "id": "6d3174b7-3d35-4567-8826-86c65e3edb4e",
+          "name": "manage-events",
+          "description": "${role_manage-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2800c6a1-ed8a-4c1a-b0d7-c3c24b56c59e",
+          "attributes": {}
+        },
+        {
+          "id": "12054186-f998-408f-b501-f9e9023efeea",
+          "name": "view-realm",
+          "description": "${role_view-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2800c6a1-ed8a-4c1a-b0d7-c3c24b56c59e",
+          "attributes": {}
+        },
+        {
+          "id": "dd7a1d84-2e0e-45c7-9d6e-f2bbfd36aa44",
+          "name": "view-clients",
+          "description": "${role_view-clients}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-clients"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "2800c6a1-ed8a-4c1a-b0d7-c3c24b56c59e",
+          "attributes": {}
+        },
+        {
+          "id": "049b8c45-b966-46b7-97a4-89b7c4094292",
+          "name": "manage-realm",
+          "description": "${role_manage-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2800c6a1-ed8a-4c1a-b0d7-c3c24b56c59e",
+          "attributes": {}
+        },
+        {
+          "id": "c82eb836-ccd7-4cc2-ad01-fa4e105502d8",
+          "name": "query-groups",
+          "description": "${role_query-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2800c6a1-ed8a-4c1a-b0d7-c3c24b56c59e",
+          "attributes": {}
+        },
+        {
+          "id": "2a9b1f46-13f1-49da-975f-5bd610cbc157",
+          "name": "realm-admin",
+          "description": "${role_realm-admin}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "view-users",
+                "manage-clients",
+                "manage-identity-providers",
+                "query-users",
+                "query-clients",
+                "view-authorization",
+                "view-events",
+                "manage-users",
+                "view-identity-providers",
+                "impersonation",
+                "manage-events",
+                "manage-authorization",
+                "view-realm",
+                "view-clients",
+                "manage-realm",
+                "query-groups",
+                "query-realms",
+                "create-client"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "2800c6a1-ed8a-4c1a-b0d7-c3c24b56c59e",
+          "attributes": {}
+        },
+        {
+          "id": "360bbd1d-c356-45f9-8d4e-2a80b0d64ce0",
+          "name": "query-realms",
+          "description": "${role_query-realms}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2800c6a1-ed8a-4c1a-b0d7-c3c24b56c59e",
+          "attributes": {}
+        },
+        {
+          "id": "41247388-366e-4d5b-8d59-6a259281e43c",
+          "name": "create-client",
+          "description": "${role_create-client}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2800c6a1-ed8a-4c1a-b0d7-c3c24b56c59e",
+          "attributes": {}
+        }
+      ],
+      "security-admin-console": [],
+      "admin-cli": [],
+      "account-console": [],
+      "broker": [
+        {
+          "id": "ec6039cc-1444-41c5-a805-d7cf8f467c8e",
+          "name": "read-token",
+          "description": "${role_read-token}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d7dcde4c-8dee-4b37-879a-3dff440f6c9e",
+          "attributes": {}
+        }
+      ],
+      "account": [
+        {
+          "id": "b231761e-2e37-4c3c-8431-656fdc6056aa",
+          "name": "view-profile",
+          "description": "${role_view-profile}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "22218f77-2138-4118-8d8d-a5dfd444040a",
+          "attributes": {}
+        },
+        {
+          "id": "1b56778d-5b19-44da-a3b8-56a57a6b8c97",
+          "name": "delete-account",
+          "description": "${role_delete-account}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "22218f77-2138-4118-8d8d-a5dfd444040a",
+          "attributes": {}
+        },
+        {
+          "id": "9fffcdd5-0e2b-4233-9f64-688615481953",
+          "name": "view-applications",
+          "description": "${role_view-applications}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "22218f77-2138-4118-8d8d-a5dfd444040a",
+          "attributes": {}
+        },
+        {
+          "id": "5e667a66-e1eb-4229-ae77-a030592c5c78",
+          "name": "manage-consent",
+          "description": "${role_manage-consent}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "view-consent"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "22218f77-2138-4118-8d8d-a5dfd444040a",
+          "attributes": {}
+        },
+        {
+          "id": "93a5d7c2-746f-4c10-9f17-4252e853cd1b",
+          "name": "view-groups",
+          "description": "${role_view-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "22218f77-2138-4118-8d8d-a5dfd444040a",
+          "attributes": {}
+        },
+        {
+          "id": "66fc1612-36e1-4f40-a12f-5975cc568e22",
+          "name": "manage-account",
+          "description": "${role_manage-account}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "manage-account-links"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "22218f77-2138-4118-8d8d-a5dfd444040a",
+          "attributes": {}
+        },
+        {
+          "id": "5b662ac7-b867-4f96-85c0-6db2cbf1bdd6",
+          "name": "manage-account-links",
+          "description": "${role_manage-account-links}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "22218f77-2138-4118-8d8d-a5dfd444040a",
+          "attributes": {}
+        },
+        {
+          "id": "24e09188-8a95-4622-8c0f-4eab72a51f71",
+          "name": "view-consent",
+          "description": "${role_view-consent}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "22218f77-2138-4118-8d8d-a5dfd444040a",
+          "attributes": {}
+        }
+      ]
+    }
+  },
+  "groups": [],
+  "defaultRole": {
+    "id": "eddf3a53-0ecf-40f3-a043-e293720ec174",
+    "name": "default-roles-lucky-logistics",
+    "description": "${role_default-roles}",
+    "composite": true,
+    "clientRole": false,
+    "containerId": "858285af-3491-4c05-af4f-a4a97844b5d4"
+  },
+  "requiredCredentials": [
+    "password"
+  ],
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyInitialCounter": 0,
+  "otpPolicyDigits": 6,
+  "otpPolicyLookAheadWindow": 1,
+  "otpPolicyPeriod": 30,
+  "otpPolicyCodeReusable": false,
+  "otpSupportedApplications": [
+    "totpAppFreeOTPName",
+    "totpAppGoogleName",
+    "totpAppMicrosoftAuthenticatorName"
+  ],
+  "localizationTexts": {},
+  "webAuthnPolicyRpEntityName": "keycloak",
+  "webAuthnPolicySignatureAlgorithms": [
+    "ES256"
+  ],
+  "webAuthnPolicyRpId": "",
+  "webAuthnPolicyAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyRequireResidentKey": "not specified",
+  "webAuthnPolicyUserVerificationRequirement": "not specified",
+  "webAuthnPolicyCreateTimeout": 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyAcceptableAaguids": [],
+  "webAuthnPolicyExtraOrigins": [],
+  "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+    "ES256"
+  ],
+  "webAuthnPolicyPasswordlessRpId": "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout": 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+  "webAuthnPolicyPasswordlessExtraOrigins": [],
+  "scopeMappings": [
+    {
+      "clientScope": "offline_access",
+      "roles": [
+        "offline_access"
+      ]
+    }
+  ],
+  "clientScopeMappings": {
+    "account": [
+      {
+        "client": "account-console",
+        "roles": [
+          "manage-account",
+          "view-groups"
+        ]
+      }
+    ]
+  },
+  "clients": [
+    {
+      "id": "22218f77-2138-4118-8d8d-a5dfd444040a",
+      "clientId": "account",
+      "name": "${client_account}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/lucky/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/lucky/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "53849864-9124-440d-a62c-74c50a2f54e2",
+      "clientId": "account-console",
+      "name": "${client_account-console}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/lucky/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/lucky/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "+",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "8d5cd2c3-dbf2-4fd4-88fc-b0f0073ebe03",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "d814e72f-a60e-4b7a-bdcc-982f7c9c4090",
+      "clientId": "admin-cli",
+      "name": "${client_admin-cli}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "d7dcde4c-8dee-4b37-879a-3dff440f6c9e",
+      "clientId": "broker",
+      "name": "${client_broker}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "3c3af4b1-3ca2-4270-9408-3581ba53a0f1",
+      "clientId": "lucky-client",
+      "name": "",
+      "description": "",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/*"
+      ],
+      "webOrigins": [
+        "/*"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "+",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false",
+        "use.refresh.tokens": "true",
+        "oidc.ciba.grant.enabled": "false",
+        "client.use.lightweight.access.token.enabled": "false",
+        "backchannel.logout.session.required": "true",
+        "client_credentials.use_refresh_token": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "require.pushed.authorization.requests": "false",
+        "acr.loa.map": "{}",
+        "display.on.consent.screen": "false",
+        "token.response.type.bearer.lower-case": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "2800c6a1-ed8a-4c1a-b0d7-c3c24b56c59e",
+      "clientId": "realm-management",
+      "name": "${client_realm-management}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "26a8d831-7851-4fbc-b851-c4a63042375a",
+      "clientId": "security-admin-console",
+      "name": "${client_security-admin-console}",
+      "rootUrl": "${authAdminUrl}",
+      "baseUrl": "/admin/lucky/console/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/admin/lucky/console/*"
+      ],
+      "webOrigins": [
+        "+"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "+",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "716750f2-6b4e-4c8c-a1b6-309b3fdc450b",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    }
+  ],
+  "clientScopes": [
+    {
+      "id": "c3896c1f-4062-46ce-81f1-3f7cec2d61aa",
+      "name": "email",
+      "description": "OpenID Connect built-in scope: email",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${emailScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "5b2fb9a0-b74c-424f-88ca-dd0cd7520c70",
+          "name": "email verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "emailVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email_verified",
+            "jsonType.label": "boolean"
+          }
+        },
+        {
+          "id": "7ce110c6-4069-4aa9-97dd-ff0c32997da0",
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "9e54fa38-1781-4a2c-82a5-d9b263bec11b",
+      "name": "microprofile-jwt",
+      "description": "Microprofile - JWT built-in scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "74c4f063-6a6d-4c53-bd0d-b632affcd080",
+          "name": "upn",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "upn",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "e3684f6c-cbf3-4c2a-8adc-5b3c00bb0605",
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "multivalued": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "foo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "cf47c603-60bc-40de-9618-ba9735a1f36f",
+      "name": "role_list",
+      "description": "SAML role list",
+      "protocol": "saml",
+      "attributes": {
+        "consent.screen.text": "${samlRoleListScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "5d9de899-34b7-4a77-8559-1b468946a49b",
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        }
+      ]
+    },
+    {
+      "id": "3d6984f7-1fec-4ccf-88c0-2db8988ee8e5",
+      "name": "profile",
+      "description": "OpenID Connect built-in scope: profile",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${profileScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "8e7434ff-1d64-4d49-8b5c-35db05392360",
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "ce69b224-414e-4885-a856-311ed9f26f28",
+          "name": "gender",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "gender",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "gender",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "12b29390-1a6d-4d20-9914-1ecf39f1119f",
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "be56e5cd-5aeb-471f-bf0f-9f450fb1198c",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "36c3c7e4-1cd0-4ea5-8c7f-6c96ace1176e",
+          "name": "website",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "website",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "website",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "bd2c7de3-4006-4729-8945-a633295f853f",
+          "name": "middle name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "middleName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "middle_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c02c17ce-f9ac-476d-84e0-af4d4a54554c",
+          "name": "nickname",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "nickname",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "nickname",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "15e826ae-b58f-45c3-bcac-6919744698a9",
+          "name": "profile",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "profile",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "profile",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "0469996f-525a-492b-966d-607903624803",
+          "name": "birthdate",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "birthdate",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "birthdate",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "79f32b68-beb5-4f5a-b0cd-704c6feeff8d",
+          "name": "updated at",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "updatedAt",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "updated_at",
+            "jsonType.label": "long"
+          }
+        },
+        {
+          "id": "568a652d-884d-47f8-885a-d28b898f0f8c",
+          "name": "picture",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "picture",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "picture",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "6dc9ef33-c446-4af7-a26f-55fb450b86da",
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "e389f07b-ef3a-4387-9027-c2e22356f82d",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "55398978-cba1-488a-ba00-a038ac3c9e25",
+          "name": "zoneinfo",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "zoneinfo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "zoneinfo",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "12593149-ade3-49a3-a7c6-65b49af854a4",
+      "name": "phone",
+      "description": "OpenID Connect built-in scope: phone",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${phoneScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "180ad6de-a9d5-4564-9ce8-5e3434dba1cc",
+          "name": "phone number verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumberVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number_verified",
+            "jsonType.label": "boolean"
+          }
+        },
+        {
+          "id": "4c38ce83-fc22-433b-a9dc-c5fb0a336ba1",
+          "name": "phone number",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumber",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "dea7759c-4bf5-4bbe-9170-261bd5d8d441",
+      "name": "address",
+      "description": "OpenID Connect built-in scope: address",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${addressScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "04610a65-aa91-4412-a271-83d9d4aeabfd",
+          "name": "address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-address-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute.formatted": "formatted",
+            "user.attribute.country": "country",
+            "introspection.token.claim": "true",
+            "user.attribute.postal_code": "postal_code",
+            "userinfo.token.claim": "true",
+            "user.attribute.street": "street",
+            "id.token.claim": "true",
+            "user.attribute.region": "region",
+            "access.token.claim": "true",
+            "user.attribute.locality": "locality"
+          }
+        }
+      ]
+    },
+    {
+      "id": "f2164bed-5cea-4825-a911-4f931a193f53",
+      "name": "roles",
+      "description": "OpenID Connect scope for add user roles to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${rolesScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "c8b5534a-450d-4b0b-a6e2-fa23c1188c3a",
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "multivalued": "true",
+            "user.attribute": "foo",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "fc5ddbff-98f5-45d5-b2ff-ae3bea98d4af",
+          "name": "client roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-client-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "multivalued": "true",
+            "user.attribute": "foo",
+            "access.token.claim": "true",
+            "claim.name": "resource_access.${client_id}.roles",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "1be72246-1894-449f-99e5-728933fd4bd1",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "6ec957bc-fb16-4d56-b321-876dbba95419",
+      "name": "acr",
+      "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "3e06802f-b0dc-4d68-9e49-6a5eff28dfe1",
+          "name": "acr loa level",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-acr-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "dfb2b7b8-9df3-44bd-9804-5e2bc426360e",
+      "name": "offline_access",
+      "description": "OpenID Connect built-in scope: offline_access",
+      "protocol": "openid-connect",
+      "attributes": {
+        "consent.screen.text": "${offlineAccessScopeConsentText}",
+        "display.on.consent.screen": "true"
+      }
+    },
+    {
+      "id": "778f1e76-6dc9-440e-991e-2409ebcf39b4",
+      "name": "web-origins",
+      "description": "OpenID Connect scope for add allowed web origins to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false",
+        "consent.screen.text": ""
+      },
+      "protocolMappers": [
+        {
+          "id": "913591a7-51ff-4444-a0bf-f9f87b08c5eb",
+          "name": "allowed web origins",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-allowed-origins-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "defaultDefaultClientScopes": [
+    "role_list",
+    "profile",
+    "email",
+    "roles",
+    "web-origins",
+    "acr"
+  ],
+  "defaultOptionalClientScopes": [
+    "offline_access",
+    "address",
+    "phone",
+    "microprofile-jwt"
+  ],
+  "browserSecurityHeaders": {
+    "contentSecurityPolicyReportOnly": "",
+    "xContentTypeOptions": "nosniff",
+    "referrerPolicy": "no-referrer",
+    "xRobotsTag": "none",
+    "xFrameOptions": "SAMEORIGIN",
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection": "1; mode=block",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer": {},
+  "eventsEnabled": false,
+  "eventsListeners": [
+    "jboss-logging"
+  ],
+  "enabledEventTypes": [],
+  "adminEventsEnabled": false,
+  "adminEventsDetailsEnabled": false,
+  "identityProviders": [],
+  "identityProviderMappers": [],
+  "components": {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+      {
+        "id": "430463fe-c570-409c-af31-3009373bd0f4",
+        "name": "Trusted Hosts",
+        "providerId": "trusted-hosts",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "host-sending-registration-request-must-match": [
+            "true"
+          ],
+          "client-uris-must-match": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "20441328-f9d7-4d21-abd8-22a7ca4e89ff",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "e676c612-635b-48ab-8bfa-6a1a2bfb0cb6",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "c3c60d41-247e-4d46-931f-c31c9091fa0b",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-usermodel-property-mapper",
+            "oidc-address-mapper",
+            "oidc-full-name-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "saml-user-property-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "saml-user-attribute-mapper",
+            "saml-role-list-mapper"
+          ]
+        }
+      },
+      {
+        "id": "027439cd-7944-48b6-a960-5281a9a68316",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "saml-user-property-mapper",
+            "oidc-address-mapper",
+            "oidc-full-name-mapper",
+            "oidc-usermodel-property-mapper",
+            "saml-user-attribute-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "saml-role-list-mapper",
+            "oidc-sha256-pairwise-sub-mapper"
+          ]
+        }
+      },
+      {
+        "id": "3a90da64-3c23-4336-a420-d961b3086ab0",
+        "name": "Consent Required",
+        "providerId": "consent-required",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "1970584f-10e0-4fea-9e97-9a1526a1b268",
+        "name": "Full Scope Disabled",
+        "providerId": "scope",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "59658437-3a37-4dd4-b6a0-8a8d165067ba",
+        "name": "Max Clients Limit",
+        "providerId": "max-clients",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "max-clients": [
+            "200"
+          ]
+        }
+      }
+    ],
+    "org.keycloak.keys.KeyProvider": [
+      {
+        "id": "28c990ad-0d1c-4323-ace7-89d4390cd44a",
+        "name": "aes-generated",
+        "providerId": "aes-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ]
+        }
+      },
+      {
+        "id": "9dd51674-f636-4fec-8a72-7130d9bb6d3e",
+        "name": "rsa-enc-generated",
+        "providerId": "rsa-enc-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "RSA-OAEP"
+          ]
+        }
+      },
+      {
+        "id": "dd837214-0824-4f1a-b1a4-46ff260d7b96",
+        "name": "rsa-generated",
+        "providerId": "rsa-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ]
+        }
+      },
+      {
+        "id": "9ff23918-3068-4eea-a6ff-ce0b1790dea5",
+        "name": "hmac-generated-hs512",
+        "providerId": "hmac-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "HS512"
+          ]
+        }
+      }
+    ]
+  },
+  "internationalizationEnabled": false,
+  "supportedLocales": [],
+  "authenticationFlows": [
+    {
+      "id": "bd36f853-38b4-40ba-9a3c-d9c529b94318",
+      "alias": "Account verification options",
+      "description": "Method with which to verity the existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-email-verification",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Verify Existing Account by Re-authentication",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "2ef216cf-9811-4a65-abb5-af076e51b529",
+      "alias": "Browser - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "2d548af4-dfc8-4c92-aee3-882cee5f7225",
+      "alias": "Direct Grant - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "direct-grant-validate-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "35949e2a-2e39-4c3a-ba65-9db00916daa7",
+      "alias": "First broker login - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "00c4ab69-4541-47c9-b0b4-5dc7ccb63080",
+      "alias": "Handle Existing Account",
+      "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-confirm-link",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Account verification options",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "291d1d4c-e399-4846-9bb8-4db972f02ad2",
+      "alias": "Reset - Conditional OTP",
+      "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "9f0fd1f7-1fe7-44ab-acc5-654ff21e9934",
+      "alias": "User creation or linking",
+      "description": "Flow for the existing/non-existing user alternatives",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "create unique user config",
+          "authenticator": "idp-create-user-if-unique",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Handle Existing Account",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "6ed025ab-119c-419d-9497-821af1f566b5",
+      "alias": "Verify Existing Account by Re-authentication",
+      "description": "Reauthentication of existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "First broker login - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "a5a2e758-71c3-4afe-9fe3-16b83ada77fb",
+      "alias": "browser",
+      "description": "browser based authentication",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 25,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": true,
+          "flowAlias": "forms",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "16aede19-809c-4a07-b5eb-14b4db58591a",
+      "alias": "clients",
+      "description": "Base authentication for clients",
+      "providerId": "client-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "client-secret",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-secret-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-x509",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 40,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "4d898c8e-7465-4ffa-8ebf-bd5a57335651",
+      "alias": "direct grant",
+      "description": "OpenID Connect Resource Owner Grant",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "direct-grant-validate-username",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "direct-grant-validate-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 30,
+          "autheticatorFlow": true,
+          "flowAlias": "Direct Grant - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "b4fddfc9-9399-4d7d-8988-9567eadf6d85",
+      "alias": "docker auth",
+      "description": "Used by Docker clients to authenticate against the IDP",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "docker-http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "49f5e173-cb0a-4152-a9a1-013f2741133c",
+      "alias": "first broker login",
+      "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "review profile config",
+          "authenticator": "idp-review-profile",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "User creation or linking",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "51891e25-c084-4964-a4f0-f961f3814af1",
+      "alias": "forms",
+      "description": "Username, password, otp and other auth forms.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Browser - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "215795fd-0ff6-4513-9a37-3352bee7d484",
+      "alias": "registration",
+      "description": "registration flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-page-form",
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": true,
+          "flowAlias": "registration form",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "6c5fef40-2f43-49b5-9ede-0fa4a073a8b8",
+      "alias": "registration form",
+      "description": "registration form",
+      "providerId": "form-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-user-creation",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-password-action",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 50,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-recaptcha-action",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 60,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-terms-and-conditions",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 70,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "0ce62840-7dc1-4258-acb1-f6493340de71",
+      "alias": "reset credentials",
+      "description": "Reset credentials for a user if they forgot their password or something",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "reset-credentials-choose-user",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-credential-email",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 40,
+          "autheticatorFlow": true,
+          "flowAlias": "Reset - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "b8491055-9e7e-45b9-9814-44f53d3b992f",
+      "alias": "saml ecp",
+      "description": "SAML ECP Profile Authentication Flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    }
+  ],
+  "authenticatorConfig": [
+    {
+      "id": "4a651ad2-9db1-4e3b-93c9-c8e132897a5b",
+      "alias": "create unique user config",
+      "config": {
+        "require.password.update.after.registration": "false"
+      }
+    },
+    {
+      "id": "07f27865-52ab-4674-a007-588bb51d9486",
+      "alias": "review profile config",
+      "config": {
+        "update.profile.on.first.login": "missing"
+      }
+    }
+  ],
+  "requiredActions": [
+    {
+      "alias": "CONFIGURE_TOTP",
+      "name": "Configure OTP",
+      "providerId": "CONFIGURE_TOTP",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 10,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PASSWORD",
+      "name": "Update Password",
+      "providerId": "UPDATE_PASSWORD",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 20,
+      "config": {}
+    },
+    {
+      "alias": "TERMS_AND_CONDITIONS",
+      "name": "Terms and Conditions",
+      "providerId": "TERMS_AND_CONDITIONS",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 30,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PROFILE",
+      "name": "Update Profile",
+      "providerId": "UPDATE_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 40,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_EMAIL",
+      "name": "Verify Email",
+      "providerId": "VERIFY_EMAIL",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 50,
+      "config": {}
+    },
+    {
+      "alias": "delete_account",
+      "name": "Delete Account",
+      "providerId": "delete_account",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 60,
+      "config": {}
+    },
+    {
+      "alias": "webauthn-register",
+      "name": "Webauthn Register",
+      "providerId": "webauthn-register",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 70,
+      "config": {}
+    },
+    {
+      "alias": "webauthn-register-passwordless",
+      "name": "Webauthn Register Passwordless",
+      "providerId": "webauthn-register-passwordless",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 80,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_PROFILE",
+      "name": "Verify Profile",
+      "providerId": "VERIFY_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 90,
+      "config": {}
+    },
+    {
+      "alias": "update_user_locale",
+      "name": "Update User Locale",
+      "providerId": "update_user_locale",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 1000,
+      "config": {}
+    }
+  ],
+  "browserFlow": "browser",
+  "registrationFlow": "registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "reset credentials",
+  "clientAuthenticationFlow": "clients",
+  "dockerAuthenticationFlow": "docker auth",
+  "firstBrokerLoginFlow": "first broker login",
+  "attributes": {
+    "cibaBackchannelTokenDeliveryMode": "poll",
+    "cibaAuthRequestedUserHint": "login_hint",
+    "clientOfflineSessionMaxLifespan": "0",
+    "oauth2DevicePollingInterval": "5",
+    "clientSessionIdleTimeout": "0",
+    "actionTokenGeneratedByUserLifespan.verify-email": "",
+    "actionTokenGeneratedByUserLifespan.idp-verify-account-via-email": "",
+    "clientOfflineSessionIdleTimeout": "0",
+    "actionTokenGeneratedByUserLifespan.execute-actions": "",
+    "cibaInterval": "5",
+    "realmReusableOtpCode": "false",
+    "cibaExpiresIn": "120",
+    "oauth2DeviceCodeLifespan": "600",
+    "parRequestUriLifespan": "60",
+    "clientSessionMaxLifespan": "0",
+    "frontendUrl": "",
+    "acr.loa.map": "{}",
+    "shortVerificationUri": "",
+    "actionTokenGeneratedByUserLifespan.reset-credentials": ""
+  },
+  "keycloakVersion": "24.0.0",
+  "userManagedAccessAllowed": false,
+  "clientProfiles": {
+    "profiles": []
+  },
+  "clientPolicies": {
+    "policies": []
+  }
+}

--- a/notification-service/build.gradle
+++ b/notification-service/build.gradle
@@ -12,4 +12,9 @@ dependencies {
 	implementation 'org.apache.httpcomponents.client5:httpclient5'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+	implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+	implementation 'io.github.openfeign:feign-micrometer'  // notification은 Feign 씀
 }

--- a/notification-service/src/main/java/com/sparta/lucky/notification/NotificationServiceApplication.java
+++ b/notification-service/src/main/java/com/sparta/lucky/notification/NotificationServiceApplication.java
@@ -1,10 +1,11 @@
 package com.sparta.lucky.notification;
 
+import com.sparta.lucky.notification.infrastructure.client.FeignConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 
-@EnableFeignClients
+@EnableFeignClients(defaultConfiguration = FeignConfig.class)
 @SpringBootApplication
 public class NotificationServiceApplication {
 

--- a/notification-service/src/main/java/com/sparta/lucky/notification/common/config/SecurityConfig.java
+++ b/notification-service/src/main/java/com/sparta/lucky/notification/common/config/SecurityConfig.java
@@ -38,8 +38,7 @@ public class SecurityConfig {
                 .addFilterBefore(headerAuthenticationFilter,
                         UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(internalRequestFilter,
-                        HeaderAuthenticationFilter.class)
-                .oauth2ResourceServer(oauth -> oauth.jwt(Customizer.withDefaults()));
+                        HeaderAuthenticationFilter.class);
         return http.build();
     }
 }

--- a/notification-service/src/main/java/com/sparta/lucky/notification/common/config/SecurityConfig.java
+++ b/notification-service/src/main/java/com/sparta/lucky/notification/common/config/SecurityConfig.java
@@ -5,7 +5,6 @@ import com.sparta.lucky.notification.common.filter.InternalRequestFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;

--- a/notification-service/src/main/java/com/sparta/lucky/notification/common/exception/GlobalExceptionHandler.java
+++ b/notification-service/src/main/java/com/sparta/lucky/notification/common/exception/GlobalExceptionHandler.java
@@ -58,6 +58,6 @@ public class GlobalExceptionHandler {
         log.warn("Access Denied: {}", e.getMessage());
         return ResponseEntity
                 .status(HttpStatus.FORBIDDEN)
-                .body(ApiResponse.error("ORDER_ACCESS_DENIED", "접근 권한이 없습니다."));
+                .body(ApiResponse.error(NotificationErrorCode.ACCESS_DENIED.getCode(), NotificationErrorCode.ACCESS_DENIED.getMessage()));
     }
 }

--- a/notification-service/src/main/java/com/sparta/lucky/notification/common/exception/GlobalExceptionHandler.java
+++ b/notification-service/src/main/java/com/sparta/lucky/notification/common/exception/GlobalExceptionHandler.java
@@ -52,4 +52,12 @@ public class GlobalExceptionHandler {
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ApiResponse.error("INTERNAL_ERROR", "서버 오류가 발생했습니다."));
     }
+
+    @ExceptionHandler(org.springframework.security.authorization.AuthorizationDeniedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAccessDenied(Exception e) {
+        log.warn("Access Denied: {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
+                .body(ApiResponse.error("ORDER_ACCESS_DENIED", "접근 권한이 없습니다."));
+    }
 }

--- a/notification-service/src/main/java/com/sparta/lucky/notification/infrastructure/client/FeignConfig.java
+++ b/notification-service/src/main/java/com/sparta/lucky/notification/infrastructure/client/FeignConfig.java
@@ -1,0 +1,16 @@
+package com.sparta.lucky.notification.infrastructure.client;
+
+import feign.micrometer.MicrometerObservationCapability;
+import io.micrometer.observation.ObservationRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FeignConfig {
+
+    @Bean
+    public MicrometerObservationCapability micrometerObservationCapability(
+            ObservationRegistry registry) {
+        return new MicrometerObservationCapability(registry);
+    }
+}

--- a/notification-service/src/main/resources/application.yml
+++ b/notification-service/src/main/resources/application.yml
@@ -42,6 +42,9 @@ management:
   tracing:
     sampling:
       probability: 1.0
+  zipkin:
+    tracing:
+      endpoint: http://lucky-zipkin:9411/api/v2/spans  # 추가
 
 gemini:
   api:

--- a/notification-service/src/main/resources/application.yml
+++ b/notification-service/src/main/resources/application.yml
@@ -27,9 +27,8 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: http://lucky-keycloak:8080/realms/lucky
-          jwk-set-uri: http://lucky-keycloak:8080/realms/lucky/protocol/openid-connect/certs
-
+          issuer-uri: ${KEYCLOAK_ISSUER_URI:http://localhost:9090/realms/lucky}
+          jwk-set-uri: ${KEYCLOAK_JWK_SET_URI:http://lucky-keycloak:8080/realms/lucky/protocol/openid-connect/certs}
 eureka:
   client:
     service-url:

--- a/notification-service/src/test/http/keycloak-auth.http
+++ b/notification-service/src/test/http/keycloak-auth.http
@@ -14,11 +14,14 @@ Content-Type: application/x-www-form-urlencoded
 grant_type=password&client_id=lucky-client&username=master-user&password={{masterPassword}}
 
 > {%
-    client.global.set("accessToken", response.body.access_token);
+
     client.test("MASTER 토큰 발급 성공", function() {
         client.assert(response.status === 200, "status 200 expected");
         client.assert(response.body.access_token !== undefined, "access_token 반환 필요");
     });
+    if (response.status === 200 && response.body.access_token) {
+        client.global.set("accessToken", response.body.access_token);
+    }
 %}
 
 ### [2] COMPANY_MANAGER 토큰 발급
@@ -28,10 +31,14 @@ Content-Type: application/x-www-form-urlencoded
 grant_type=password&client_id=lucky-client&username=company-manager-user&password={{masterPassword}}
 
 > {%
-    client.global.set("companyManagerToken", response.body.access_token);
+
     client.test("COMPANY_MANAGER 토큰 발급 성공", function() {
         client.assert(response.status === 200, "status 200 expected");
+        client.assert(response.body.access_token !== undefined, "access_token 반환 필요");
     });
+    if (response.status === 200 && response.body.access_token) {
+        client.global.set("companyManagerToken", response.body.access_token);
+    }
 %}
 
 ### [3] HUB_MANAGER 토큰 발급
@@ -41,8 +48,12 @@ Content-Type: application/x-www-form-urlencoded
 grant_type=password&client_id=lucky-client&username=hub-manager-user&password={{masterPassword}}
 
 > {%
-    client.global.set("hubManagerToken", response.body.access_token);
+
     client.test("HUB_MANAGER 토큰 발급 성공", function() {
         client.assert(response.status === 200, "status 200 expected");
+        client.assert(response.body.access_token !== undefined, "access_token 반환 필요");
     });
+    if (response.status === 200 && response.body.access_token) {
+        client.global.set("hubManagerToken", response.body.access_token);
+    }
 %}

--- a/notification-service/src/test/http/keycloak-auth.http
+++ b/notification-service/src/test/http/keycloak-auth.http
@@ -1,0 +1,48 @@
+### ================================================================
+### Keycloak 인증 - 테스트용 토큰 발급
+###
+### 사용법:
+###   1. 환경 드롭다운에서 'gateway' 선택
+###   2. 아래 요청 순서대로 실행 → accessToken이 global 변수에 자동 저장
+###   3. order-crud.http, order-internal.http 에서 {{accessToken}} 으로 사용
+### ================================================================
+
+### [1] MASTER 토큰 발급
+POST {{keycloakUrl}}/realms/lucky/protocol/openid-connect/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=password&client_id=lucky-client&username=master-user&password={{masterPassword}}
+
+> {%
+    client.global.set("accessToken", response.body.access_token);
+    client.test("MASTER 토큰 발급 성공", function() {
+        client.assert(response.status === 200, "status 200 expected");
+        client.assert(response.body.access_token !== undefined, "access_token 반환 필요");
+    });
+%}
+
+### [2] COMPANY_MANAGER 토큰 발급
+POST {{keycloakUrl}}/realms/lucky/protocol/openid-connect/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=password&client_id=lucky-client&username=company-manager-user&password={{masterPassword}}
+
+> {%
+    client.global.set("companyManagerToken", response.body.access_token);
+    client.test("COMPANY_MANAGER 토큰 발급 성공", function() {
+        client.assert(response.status === 200, "status 200 expected");
+    });
+%}
+
+### [3] HUB_MANAGER 토큰 발급
+POST {{keycloakUrl}}/realms/lucky/protocol/openid-connect/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=password&client_id=lucky-client&username=hub-manager-user&password={{masterPassword}}
+
+> {%
+    client.global.set("hubManagerToken", response.body.access_token);
+    client.test("HUB_MANAGER 토큰 발급 성공", function() {
+        client.assert(response.status === 200, "status 200 expected");
+    });
+%}

--- a/notification-service/src/test/http/notification-test.http
+++ b/notification-service/src/test/http/notification-test.http
@@ -17,7 +17,7 @@
 ### - SlackMessage + AiMessage DB 저장
 ### ================================================================
 ### @name sendOrderAlert
-POST {{notiUrl}}/internal/v1/notifications/order-alert
+POST {{notiUrl}}/internal/api/v1/notifications/order-alert
 Content-Type: application/json
 X-Internal-Request: true
 
@@ -26,9 +26,8 @@ X-Internal-Request: true
   "expectedTotalDurationSeconds": 23400,
   "expectedTotalDistanceMeter": 428000,
   "routes": [
-    "실제-허브-UUID-1",
-    "실제-허브-UUID-2",
-    "실제-허브-UUID-3"
+    "cccccccc-cccc-cccc-cccc-cccccccccccc",
+    "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
   ]
 }
 

--- a/notification-service/src/test/http/notification-test.http
+++ b/notification-service/src/test/http/notification-test.http
@@ -152,7 +152,7 @@ Authorization: Bearer {{accessToken}}
 
 ### [9] 내부 API 헤더 없음 → 403 expected
 ### @name missingInternalHeader
-POST {{notiUrl}}/internal/v1/notifications/order-alert
+POST {{notiUrl}}/internal/api/v1/notifications/order-alert
 Content-Type: application/json
 
 {

--- a/notification-service/src/test/http/notification-test.http
+++ b/notification-service/src/test/http/notification-test.http
@@ -1,0 +1,202 @@
+### ================================================================
+### Notification Service - API 테스트
+###
+### 사전 조건:
+###   1. docker-compose로 인프라 + 전체 서비스 실행
+###   2. order-crud.http [1] 실행 → orderId 글로벌 변수 확보
+###   3. keycloak-auth.http 실행 → accessToken 확보
+###   4. 외부 API: 환경 드롭다운에서 'gateway' 선택
+###      내부 API: 환경 드롭다운에서 'local' 선택
+### ================================================================
+
+### ================================================================
+### [1] 주문 알림 발송 (내부) — delivery-service 경로 생성 완료 시뮬레이션
+### - hub-service에서 허브 이름 조회
+### - Gemini AI로 발송 시한 역산 계산
+### - 출발 허브 담당자 Slack으로 알림 발송
+### - SlackMessage + AiMessage DB 저장
+### ================================================================
+### @name sendOrderAlert
+POST {{notiUrl}}/internal/v1/notifications/order-alert
+Content-Type: application/json
+X-Internal-Request: true
+
+{
+  "orderId": "{{orderId}}",
+  "expectedTotalDurationSeconds": 23400,
+  "expectedTotalDistanceMeter": 428000,
+  "routes": [
+    "실제-허브-UUID-1",
+    "실제-허브-UUID-2",
+    "실제-허브-UUID-3"
+  ]
+}
+
+> {%
+    client.test("주문 알림 발송 성공", function() {
+        client.assert(response.status === 200);
+    });
+%}
+
+### ================================================================
+### [2] 슬랙 직접 발송 (외부)
+### ================================================================
+### @name sendSlack
+POST {{notiUrl}}/api/v1/notifications/slack
+Authorization: Bearer {{accessToken}}
+Content-Type: application/json
+
+{
+  "receiverSlackId": "실제-슬랙-ID",
+  "messageContent": "테스트 메시지입니다",
+  "relatedOrderId": "{{orderId}}"
+}
+
+> {%
+    client.test("슬랙 직접 발송 성공", function() {
+        client.assert(response.status === 200);
+        client.assert(response.body.data.id !== undefined, "slackMessageId 반환 필요");
+    });
+    if (response.status === 200 && response.body.data) {
+        client.global.set("slackMessageId", response.body.data.id);
+    }
+%}
+
+### ================================================================
+### [3] 슬랙 메시지 목록 조회 (MASTER)
+### ================================================================
+### @name getSlackMessages
+GET {{notiUrl}}/api/v1/notifications/slack?size=10
+Authorization: Bearer {{accessToken}}
+
+> {%
+    client.test("슬랙 메시지 목록 조회 성공", function() {
+        client.assert(response.status === 200);
+        client.assert(response.body.data.content !== undefined);
+    });
+%}
+
+### ================================================================
+### [4] 슬랙 메시지 목록 조회 - messageType 필터 (ORDER_NOTIFY)
+### ================================================================
+### @name getSlackMessagesByType
+GET {{notiUrl}}/api/v1/notifications/slack?messageType=ORDER_NOTIFY&size=10
+Authorization: Bearer {{accessToken}}
+
+> {%
+    client.test("ORDER_NOTIFY 필터 조회 성공", function() {
+        client.assert(response.status === 200);
+    });
+%}
+
+### ================================================================
+### [5] 슬랙 메시지 단건 조회
+### ================================================================
+### @name getSlackMessage
+GET {{notiUrl}}/api/v1/notifications/slack/{{slackMessageId}}
+Authorization: Bearer {{accessToken}}
+
+> {%
+    client.test("슬랙 메시지 단건 조회 성공", function() {
+        client.assert(response.status === 200);
+        client.assert(response.body.data.id === client.global.get("slackMessageId"));
+    });
+%}
+
+### ================================================================
+### [6] AI 메시지 목록 조회 (발송 시한 계산 결과 확인)
+### ================================================================
+### @name getAiMessages
+GET {{notiUrl}}/api/v1/notifications/ai?size=10
+Authorization: Bearer {{accessToken}}
+
+> {%
+    client.test("AI 메시지 목록 조회 성공", function() {
+        client.assert(response.status === 200);
+        client.assert(response.body.data.content !== undefined);
+    });
+    if (response.status === 200 && response.body.data.content.length > 0) {
+        client.global.set("aiMessageId", response.body.data.content[0].id);
+    }
+%}
+
+### ================================================================
+### [7] AI 메시지 단건 조회 (deadlineResult 확인)
+### ================================================================
+### @name getAiMessage
+GET {{notiUrl}}/api/v1/notifications/ai/{{aiMessageId}}
+Authorization: Bearer {{accessToken}}
+
+> {%
+    client.test("AI 메시지 단건 조회 성공", function() {
+        client.assert(response.status === 200);
+        client.assert(response.body.data.deadlineResult !== undefined, "deadlineResult 반환 필요");
+    });
+%}
+
+### ================================================================
+### [8] 슬랙 메시지 삭제 (Soft Delete)
+### ================================================================
+### @name deleteSlackMessage
+DELETE {{notiUrl}}/api/v1/notifications/slack/{{slackMessageId}}
+Authorization: Bearer {{accessToken}}
+
+> {%
+    client.test("슬랙 메시지 삭제 성공 (Soft Delete)", function() {
+        client.assert(response.status === 200);
+    });
+%}
+
+### ================================================================
+### 오류 케이스
+### ================================================================
+
+### [9] 내부 API 헤더 없음 → 403 expected
+### @name missingInternalHeader
+POST {{notiUrl}}/internal/v1/notifications/order-alert
+Content-Type: application/json
+
+{
+  "orderId": "{{orderId}}",
+  "expectedTotalDurationSeconds": 23400,
+  "expectedTotalDistanceMeter": 428000,
+  "routes": []
+}
+
+> {%
+    client.test("헤더 누락 시 403", function() {
+        client.assert(response.status === 403);
+    });
+%}
+
+### [10] 인증 토큰 없이 요청 → 401 expected
+### @name unauthorizedRequest
+GET {{notiUrl}}/api/v1/notifications/slack
+
+> {%
+    client.test("인증 실패 (401)", function() {
+        client.assert(response.status === 401);
+    });
+%}
+
+### [11] 존재하지 않는 슬랙 메시지 조회 → 404 expected
+### @name notFoundSlackMessage
+GET {{notiUrl}}/api/v1/notifications/slack/00000000-0000-0000-0000-000000000099
+Authorization: Bearer {{accessToken}}
+
+> {%
+    client.test("슬랙 메시지 없음 (404)", function() {
+        client.assert(response.status === 404);
+    });
+%}
+
+### [12] 존재하지 않는 AI 메시지 조회 → 404 expected
+### @name notFoundAiMessage
+GET {{notiUrl}}/api/v1/notifications/ai/00000000-0000-0000-0000-000000000099
+Authorization: Bearer {{accessToken}}
+
+> {%
+    client.test("AI 메시지 없음 (404)", function() {
+        client.assert(response.status === 404);
+    });
+%}

--- a/order-service/build.gradle
+++ b/order-service/build.gradle
@@ -2,4 +2,9 @@ dependencies {
     testImplementation 'com.h2database:h2'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+    implementation 'io.github.openfeign:feign-micrometer'  // notification은 Feign 씀
 }

--- a/order-service/src/main/java/com/sparta/lucky/order/OrderServiceApplication.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/OrderServiceApplication.java
@@ -1,11 +1,12 @@
 package com.sparta.lucky.order;
 
+import com.sparta.lucky.order.infrastructure.client.FeignConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
-@EnableFeignClients
+@EnableFeignClients(defaultConfiguration = FeignConfig.class)
 public class OrderServiceApplication {
 
 	public static void main(String[] args) {

--- a/order-service/src/main/java/com/sparta/lucky/order/common/config/SecurityConfig.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/common/config/SecurityConfig.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;

--- a/order-service/src/main/java/com/sparta/lucky/order/common/config/SecurityConfig.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/common/config/SecurityConfig.java
@@ -34,8 +34,7 @@ public class SecurityConfig {
                 .addFilterBefore(headerAuthenticationFilter,
                         UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(internalRequestFilter,
-                        HeaderAuthenticationFilter.class)
-                .oauth2ResourceServer(oauth -> oauth.jwt(Customizer.withDefaults()));
+                        HeaderAuthenticationFilter.class);
         return http.build();
     }
 

--- a/order-service/src/main/java/com/sparta/lucky/order/common/exception/GlobalExceptionHandler.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/common/exception/GlobalExceptionHandler.java
@@ -52,4 +52,12 @@ public class GlobalExceptionHandler {
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ApiResponse.error("INTERNAL_ERROR", "서버 오류가 발생했습니다."));
     }
+
+    @ExceptionHandler(org.springframework.security.authorization.AuthorizationDeniedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAccessDenied(Exception e) {
+        log.warn("Access Denied: {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
+                .body(ApiResponse.error("ORDER_ACCESS_DENIED", "접근 권한이 없습니다."));
+    }
 }

--- a/order-service/src/main/java/com/sparta/lucky/order/common/filter/HeaderAuthenticationFilter.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/common/filter/HeaderAuthenticationFilter.java
@@ -4,6 +4,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.lang.NonNull;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -13,7 +14,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.List;
-
+@Slf4j
 @Component
 public class HeaderAuthenticationFilter extends OncePerRequestFilter {
 
@@ -24,6 +25,8 @@ public class HeaderAuthenticationFilter extends OncePerRequestFilter {
         String userId = request.getHeader("X-User-Id");
         String role = request.getHeader("X-User-Role");
 
+        log.info("HeaderAuthenticationFilter - userId: {}, role: {}", userId, role); // 추가
+
         if (userId != null && !userId.isBlank() && role != null && !role.isBlank()) {
             UsernamePasswordAuthenticationToken authentication =
                     new UsernamePasswordAuthenticationToken(
@@ -32,6 +35,7 @@ public class HeaderAuthenticationFilter extends OncePerRequestFilter {
                             List.of(new SimpleGrantedAuthority("ROLE_" + role))
                     );
             SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.info("SecurityContext 저장 완료 - authorities: {}", authentication.getAuthorities());
         }
         filterChain.doFilter(request, response);
     }

--- a/order-service/src/main/java/com/sparta/lucky/order/infrastructure/client/FeignConfig.java
+++ b/order-service/src/main/java/com/sparta/lucky/order/infrastructure/client/FeignConfig.java
@@ -1,0 +1,16 @@
+package com.sparta.lucky.order.infrastructure.client;
+
+import feign.micrometer.MicrometerObservationCapability;
+import io.micrometer.observation.ObservationRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FeignConfig {
+
+    @Bean
+    public MicrometerObservationCapability micrometerObservationCapability(
+            ObservationRegistry registry) {
+        return new MicrometerObservationCapability(registry);
+    }
+}

--- a/order-service/src/main/resources/application.yml
+++ b/order-service/src/main/resources/application.yml
@@ -27,9 +27,8 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: ${KEYCLOAK_ISSUER_URI:http://lucky-keycloak:8080/realms/lucky}  # 환경변수로
+          issuer-uri: ${KEYCLOAK_ISSUER_URI:http://localhost:9090/realms/lucky}
           jwk-set-uri: ${KEYCLOAK_JWK_SET_URI:http://lucky-keycloak:8080/realms/lucky/protocol/openid-connect/certs}
-
 eureka:
   client:
     service-url:

--- a/order-service/src/main/resources/application.yml
+++ b/order-service/src/main/resources/application.yml
@@ -27,10 +27,8 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: http://lucky-keycloak:8080/realms/lucky
-          jwk-set-uri: http://lucky-keycloak:8080/realms/lucky/protocol/openid-connect/certs
-#    internal-request:
-#      secret: ${INTERNAL_REQUEST_SECRET:lucky-internal-secret}
+          issuer-uri: ${KEYCLOAK_ISSUER_URI:http://lucky-keycloak:8080/realms/lucky}  # 환경변수로
+          jwk-set-uri: ${KEYCLOAK_JWK_SET_URI:http://lucky-keycloak:8080/realms/lucky/protocol/openid-connect/certs}
 
 eureka:
   client:
@@ -43,6 +41,9 @@ management:
   tracing:
     sampling:
       probability: 1.0
+  zipkin:
+    tracing:
+      endpoint: http://lucky-zipkin:9411/api/v2/spans  # 추가
 
 feign:
   client:

--- a/order-service/src/test/http/keycloak-auth.http
+++ b/order-service/src/test/http/keycloak-auth.http
@@ -11,7 +11,7 @@
 POST {{keycloakUrl}}/realms/lucky/protocol/openid-connect/token
 Content-Type: application/x-www-form-urlencoded
 
-grant_type=password&client_id=lucky-client&username=master-user&password={{masterPassword}}
+grant_type=password&client_id=lucky-client&username={{masterUsername}}&password={{masterPassword}}
 
 > {%
     client.global.set("accessToken", response.body.access_token);
@@ -25,7 +25,7 @@ grant_type=password&client_id=lucky-client&username=master-user&password={{maste
 POST {{keycloakUrl}}/realms/lucky/protocol/openid-connect/token
 Content-Type: application/x-www-form-urlencoded
 
-grant_type=password&client_id=lucky-client&username=company-manager-user&password={{masterPassword}}
+grant_type=password&client_id=lucky-client&username=company&password={{masterPassword}}
 
 > {%
     client.global.set("companyManagerToken", response.body.access_token);
@@ -38,7 +38,7 @@ grant_type=password&client_id=lucky-client&username=company-manager-user&passwor
 POST {{keycloakUrl}}/realms/lucky/protocol/openid-connect/token
 Content-Type: application/x-www-form-urlencoded
 
-grant_type=password&client_id=lucky-client&username=hub-manager-user&password={{masterPassword}}
+grant_type=password&client_id=lucky-client&username=hubr&password={{masterPassword}}
 
 > {%
     client.global.set("hubManagerToken", response.body.access_token);

--- a/order-service/src/test/http/keycloak-auth.http
+++ b/order-service/src/test/http/keycloak-auth.http
@@ -1,0 +1,48 @@
+### ================================================================
+### Keycloak 인증 - 테스트용 토큰 발급
+###
+### 사용법:
+###   1. 환경 드롭다운에서 'gateway' 선택
+###   2. 아래 요청 순서대로 실행 → accessToken이 global 변수에 자동 저장
+###   3. order-crud.http, order-internal.http 에서 {{accessToken}} 으로 사용
+### ================================================================
+
+### [1] MASTER 토큰 발급
+POST {{keycloakUrl}}/realms/lucky/protocol/openid-connect/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=password&client_id=lucky-client&username=master-user&password={{masterPassword}}
+
+> {%
+    client.global.set("accessToken", response.body.access_token);
+    client.test("MASTER 토큰 발급 성공", function() {
+        client.assert(response.status === 200, "status 200 expected");
+        client.assert(response.body.access_token !== undefined, "access_token 반환 필요");
+    });
+%}
+
+### [2] COMPANY_MANAGER 토큰 발급
+POST {{keycloakUrl}}/realms/lucky/protocol/openid-connect/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=password&client_id=lucky-client&username=company-manager-user&password={{masterPassword}}
+
+> {%
+    client.global.set("companyManagerToken", response.body.access_token);
+    client.test("COMPANY_MANAGER 토큰 발급 성공", function() {
+        client.assert(response.status === 200, "status 200 expected");
+    });
+%}
+
+### [3] HUB_MANAGER 토큰 발급
+POST {{keycloakUrl}}/realms/lucky/protocol/openid-connect/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=password&client_id=lucky-client&username=hub-manager-user&password={{masterPassword}}
+
+> {%
+    client.global.set("hubManagerToken", response.body.access_token);
+    client.test("HUB_MANAGER 토큰 발급 성공", function() {
+        client.assert(response.status === 200, "status 200 expected");
+    });
+%}

--- a/order-service/src/test/http/order-crud.http
+++ b/order-service/src/test/http/order-crud.http
@@ -1,0 +1,226 @@
+### ================================================================
+### Order Service - Gateway 경유 외부 API 테스트
+###
+### 사전 조건:
+###   1. docker-compose로 인프라 (PostgreSQL, Gateway, Keycloak, Eureka) 실행
+###   2. docker-compose로 전체 서비스 실행
+###   3. 환경 드롭다운에서 'gateway' 선택
+###   4. keycloak-auth.http 실행 → accessToken 확보
+###
+### 흐름:
+### Client
+###  → Gateway (JWT 검증 + X-User-Id, X-User-Role 헤더 주입)
+###    → OrderService
+###
+### Gateway 책임:
+### - JWT 검증
+### - X-User-Id, X-User-Role 자동 주입
+### ================================================================
+
+### ================================================================
+### [1] 주문 생성 (COMPANY_MANAGER)
+### - product/company/hub/user 서비스 연쇄 호출 + 재고 차감 + 배송 생성
+### - 배송 생성 완료 후 notification-service로 Slack 알림 자동 발송
+### ================================================================
+### @name createOrder
+POST {{baseUrl}}/api/v1/orders
+Authorization: Bearer {{companyManagerToken}}
+Content-Type: application/json
+
+{
+  "requesterCompanyId": "실제-공급업체-UUID",
+  "receiverCompanyId": "실제-수령업체-UUID",
+  "productId": "실제-상품-UUID",
+  "quantity": 5,
+  "requestNote": "신선도 유지 필요. 지정 시간 내 도착 필수",
+  "requestedDeadline": "2026-04-20T15:00:00"
+}
+
+> {%
+    client.test("주문 생성 성공", function() {
+        client.assert(response.status === 201, "status 201 expected");
+        client.assert(response.body.data.id !== undefined, "orderId 반환 필요");
+        client.assert(response.body.data.status === "CREATED", "status CREATED 필요");
+    });
+    if (response.status === 201 && response.body.data) {
+        client.global.set("orderId", response.body.data.id);
+    }
+%}
+
+### ================================================================
+### [2] 주문 목록 조회 - MASTER (전체 조회)
+### ================================================================
+### @name getOrdersMaster
+GET {{baseUrl}}/api/v1/orders?size=10
+Authorization: Bearer {{accessToken}}
+
+> {%
+    client.test("MASTER 전체 주문 조회 성공", function() {
+        client.assert(response.status === 200);
+        client.assert(response.body.data.content !== undefined);
+    });
+%}
+
+### ================================================================
+### [3] 주문 목록 조회 - MASTER (status 필터)
+### ================================================================
+### @name getOrdersByStatus
+GET {{baseUrl}}/api/v1/orders?status=CREATED&size=10
+Authorization: Bearer {{accessToken}}
+
+> {%
+    client.test("status 필터 조회 성공", function() {
+        client.assert(response.status === 200);
+    });
+%}
+
+### ================================================================
+### [4] 주문 목록 조회 - COMPANY_MANAGER (담당 업체 주문만)
+### ================================================================
+### @name getOrdersCompanyManager
+GET {{baseUrl}}/api/v1/orders
+Authorization: Bearer {{companyManagerToken}}
+
+> {%
+    client.test("COMPANY_MANAGER 담당 업체 주문 조회 성공", function() {
+        client.assert(response.status === 200);
+    });
+%}
+
+### ================================================================
+### [5] 주문 목록 조회 - HUB_MANAGER (담당 허브 주문만)
+### ================================================================
+### @name getOrdersHubManager
+GET {{baseUrl}}/api/v1/orders
+Authorization: Bearer {{hubManagerToken}}
+
+> {%
+    client.test("HUB_MANAGER 담당 허브 주문 조회 성공", function() {
+        client.assert(response.status === 200);
+    });
+%}
+
+### ================================================================
+### [6] 주문 단건 조회
+### ================================================================
+### @name getOrder
+GET {{baseUrl}}/api/v1/orders/{{orderId}}
+Authorization: Bearer {{accessToken}}
+
+> {%
+    client.test("주문 단건 조회 성공", function() {
+        client.assert(response.status === 200);
+        client.assert(response.body.data.id === client.global.get("orderId"));
+    });
+%}
+
+### ================================================================
+### [7] 주문 수정 (MASTER / HUB_MANAGER - CREATED 상태만 가능)
+### ================================================================
+### @name updateOrder
+PATCH {{baseUrl}}/api/v1/orders/55555555-5555-5555-5555-555555555555
+Authorization: Bearer {{accessToken}}
+Content-Type: application/json
+
+{
+  "requestNote": "수정된 요청사항: 새벽 배송 불가",
+  "requestedDeadline": "2026-04-21T12:00:00"
+}
+
+> {%
+    client.test("주문 수정 성공", function() {
+        client.assert(response.status === 200);
+        client.assert(response.body.data.requestNote === "수정된 요청사항: 새벽 배송 불가");
+    });
+%}
+
+
+### ================================================================
+### [8] 주문 취소 (MASTER / HUB_MANAGER)
+### - CREATED 상태 + 배송 WAITING 상태만 취소 가능
+### - 재고 복원 + 배송 취소 처리
+### ================================================================
+### @name cancelOrder
+PATCH {{baseUrl}}/api/v1/orders/{{orderId}}/cancel
+Authorization: Bearer {{accessToken}}
+
+> {%
+    client.test("주문 취소 성공", function() {
+        client.assert(response.status === 200);
+        client.assert(response.body.data.status === "CANCELLED");
+    });
+%}
+
+### ================================================================
+### [9] 주문 삭제 (MASTER - Soft Delete, CANCELLED/COMPLETED 상태만)
+### ================================================================
+### @name deleteOrder
+DELETE {{baseUrl}}/api/v1/orders/{{orderId}}
+Authorization: Bearer {{accessToken}}
+
+> {%
+    client.test("주문 삭제 성공 (Soft Delete)", function() {
+        client.assert(response.status === 200);
+    });
+%}
+
+### ================================================================
+### 오류 케이스
+### ================================================================
+
+### [10] 인증 토큰 없이 요청 → 401 expected
+### @name unauthorizedRequest
+GET {{baseUrl}}/api/v1/orders
+
+> {%
+    client.test("인증 실패 (401)", function() {
+        client.assert(response.status === 401);
+    });
+%}
+
+### [11] 존재하지 않는 주문 조회 → 404 expected
+### @name notFoundOrder
+GET {{baseUrl}}/api/v1/orders/00000000-0000-0000-0000-000000000099
+Authorization: Bearer {{accessToken}}
+
+> {%
+    client.test("주문 없음 (404)", function() {
+        client.assert(response.status === 404);
+    });
+%}
+
+### [12] CANCELLED 주문 수정 시도 → 409 expected
+### @name updateCancelledOrder
+PATCH {{baseUrl}}/api/v1/orders/{{orderId}}
+Authorization: Bearer {{accessToken}}
+Content-Type: application/json
+
+{
+  "requestNote": "취소된 주문 수정 시도"
+}
+
+> {%
+    client.test("취소된 주문 수정 불가 (409)", function() {
+        client.assert(response.status === 409);
+    });
+%}
+
+### [13] COMPANY_MANAGER가 다른 업체 주문 생성 시도 → 403 expected
+### @name forbiddenCreateOrder
+POST {{baseUrl}}/api/v1/orders
+Authorization: Bearer {{companyManagerToken}}
+Content-Type: application/json
+
+{
+  "requesterCompanyId": "다른-업체-UUID",
+  "receiverCompanyId": "00000000-0000-0000-0000-000000000099",
+  "productId": "실제-상품-UUID",
+  "quantity": 1,
+  "requestNote": "권한 없는 업체 주문 시도"
+}
+
+> {%
+    client.test("권한 없는 업체 주문 생성 거부 (403)", function() {
+        client.assert(response.status === 403);
+    });
+%}

--- a/order-service/src/test/http/order-crud.http
+++ b/order-service/src/test/http/order-crud.http
@@ -118,7 +118,7 @@ Authorization: Bearer {{accessToken}}
 ### [7] 주문 수정 (MASTER / HUB_MANAGER - CREATED 상태만 가능)
 ### ================================================================
 ### @name updateOrder
-PATCH {{baseUrl}}/api/v1/orders/55555555-5555-5555-5555-555555555555
+PATCH {{baseUrl}}/api/v1/orders/{{orderId}}
 Authorization: Bearer {{accessToken}}
 Content-Type: application/json
 
@@ -133,7 +133,6 @@ Content-Type: application/json
         client.assert(response.body.data.requestNote === "수정된 요청사항: 새벽 배송 불가");
     });
 %}
-
 
 ### ================================================================
 ### [8] 주문 취소 (MASTER / HUB_MANAGER)

--- a/order-service/src/test/http/order-crud.http
+++ b/order-service/src/test/http/order-crud.http
@@ -150,6 +150,22 @@ Authorization: Bearer {{accessToken}}
     });
 %}
 
+### [12] CANCELLED 주문 수정 시도 → 409 expected
+### @name updateCancelledOrder
+PATCH {{baseUrl}}/api/v1/orders/{{orderId}}
+Authorization: Bearer {{accessToken}}
+Content-Type: application/json
+
+{
+  "requestNote": "취소된 주문 수정 시도"
+}
+
+> {%
+    client.test("취소된 주문 수정 불가 (409)", function() {
+        client.assert(response.status === 409);
+    });
+%}
+
 ### ================================================================
 ### [9] 주문 삭제 (MASTER - Soft Delete, CANCELLED/COMPLETED 상태만)
 ### ================================================================
@@ -188,21 +204,7 @@ Authorization: Bearer {{accessToken}}
     });
 %}
 
-### [12] CANCELLED 주문 수정 시도 → 409 expected
-### @name updateCancelledOrder
-PATCH {{baseUrl}}/api/v1/orders/{{orderId}}
-Authorization: Bearer {{accessToken}}
-Content-Type: application/json
 
-{
-  "requestNote": "취소된 주문 수정 시도"
-}
-
-> {%
-    client.test("취소된 주문 수정 불가 (409)", function() {
-        client.assert(response.status === 409);
-    });
-%}
 
 ### [13] COMPANY_MANAGER가 다른 업체 주문 생성 시도 → 403 expected
 ### @name forbiddenCreateOrder

--- a/order-service/src/test/http/order-internal.http
+++ b/order-service/src/test/http/order-internal.http
@@ -1,0 +1,66 @@
+### ================================================================
+### Order Service - 내부 API 테스트 (서비스 간 직접 호출 시뮬레이션)
+###
+### 사전 조건:
+###   1. docker-compose로 인프라 + 전체 서비스 실행
+###   2. order-crud.http [1] 실행 → orderId 글로벌 변수 확보
+###   3. 환경 드롭다운에서 'local' 선택 (내부 API는 Gateway 미경유, JWT 불필요)
+###
+### 내부 API 계약:
+### - X-Internal-Request: true 헤더 필수
+### - JWT 인증 없음
+### ================================================================
+
+### ================================================================
+### [1] 주문 단건 조회 (내부) — notification-service 호출 시뮬레이션
+### ================================================================
+### @name getOrderInternal
+GET {{baseUrl}}/internal/api/v1/orders/{{orderId}}
+X-Internal-Request: true
+
+> {%
+    client.test("내부 주문 조회 성공", function() {
+        client.assert(response.status === 200);
+        client.assert(response.body.data.id !== undefined, "orderId 반환 필요");
+        client.assert(response.body.data.hubManagerSlackId !== undefined, "hubManagerSlackId 반환 필요");
+    });
+%}
+
+### ================================================================
+### [2] 주문 완료 처리 (내부) — delivery-service 배송 완료 시 호출
+### ================================================================
+### @name completeOrder
+PATCH {{baseUrl}}/internal/api/v1/orders/{{orderId}}/complete
+X-Internal-Request: true
+
+> {%
+    client.test("주문 완료 처리 성공", function() {
+        client.assert(response.status === 200);
+        client.assert(response.body.data.status === "COMPLETED");
+    });
+%}
+
+### ================================================================
+### 오류 케이스
+### ================================================================
+
+### [3] 내부 API 헤더 누락 → 403 expected
+### @name missingInternalHeader
+GET {{baseUrl}}/internal/api/v1/orders/{{orderId}}
+
+> {%
+    client.test("헤더 누락 시 403", function() {
+        client.assert(response.status === 403);
+    });
+%}
+
+### [4] 존재하지 않는 주문 내부 조회 → 404 expected
+### @name notFoundOrderInternal
+GET {{baseUrl}}/internal/api/v1/orders/00000000-0000-0000-0000-000000000099
+X-Internal-Request: true
+
+> {%
+    client.test("주문 없음 (404)", function() {
+        client.assert(response.status === 404);
+    });
+%}

--- a/order-service/src/test/http/order-local.http
+++ b/order-service/src/test/http/order-local.http
@@ -1,0 +1,8 @@
+PATCH http://localhost:19500/api/v1/orders/55555555-5555-5555-5555-555555555555
+X-User-Id: 00000000-0000-0000-0000-000000000001
+X-User-Role: MASTER
+Content-Type: application/json
+
+{
+  "requestNote": "수정 테스트"
+}


### PR DESCRIPTION
## 📋 관련 이슈
> 관련 이슈 번호를 적어주세요. 
죄송합니다 이슈없이 그냥 피알했습니당..
- close #

## 🔧 작업 내용
> 
Gateway JWT 인증 연동 이슈 해결 및 Zipkin 분산 추적 설정 추가

## 변경 사항

### 인증 흐름 개선
- `SecurityConfig`에서 `oauth2ResourceServer` 제거
  - Gateway가 JWT 검증 후 X-User-Id/Role 헤더를 주입하는 구조
  - 각 서비스에서 JWT 재검증 시 HeaderAuthenticationFilter와 충돌 발생 → 제거
  - order-service, notification-service 동일 적용

### Gateway 내부 경로 허용
- `JwtAuthenticationFilter` 화이트리스트에 `/internal/` 경로 추가
  - 내부 API는 `X-Internal-Request: true` 헤더로 별도 검증
  - JWT 토큰 불필요한 서비스 간 통신 경로 허용

###  Zipkin 분산 추적 설정 -> 스크린샷 첨부
- order-service, notification-service에 Zipkin 트레이싱 추가
  - `build.gradle`: actuator, micrometer-tracing-bridge-brave, zipkin-reporter-brave 추가
  - `application.yml`: zipkin endpoint 설정
  - `FeignConfig`: MicrometerObservationCapability 추가

### 테스트 파일 정비
- `keycloak-auth.http`: 역할별 토큰 발급 (MASTER, COMPANY_MANAGER, HUB_MANAGER)
- `order-crud.http`: Gateway 경유 외부 API 테스트 + 응답 검증
- `order-internal.http`: 내부 API 테스트
- `notification-test.http`: 알림 발송 / 조회 / 삭제 테스트
- `http-client.env.json`: local/gateway 환경 분리

## 테스트 결과
- ✅ MASTER 토큰 발급 → 주문 목록/단건/수정 조회
- ✅ 내부 API 헤더 없음 → 403
- ✅ 주문 알림 발송 → Slack 실제 수신 확인
- ✅ AI 메시지 DB 저장 확인
- 주문 생성 E2E (타 서비스 머지 후)
- 주문 취소 (delivery-service 머지 후)
- 마스터는 조회가 가능하지만 본인의업체/허브 조회의경우 아직 연동이안되어 실패로 확인.

## 관련 이슈
- Gateway 경유 시 @PreAuthorize Access Denied 이슈 해결
- /internal/** 경로 JWT 필터 차단 이슈 해결

## ✅ 체크리스트
- [ ] 코드 컨벤션을 지켰나요?
- [ ] 불필요한 주석/코드를 제거했나요?
- [ ] 로컬에서 테스트 완료했나요?
- [ ] API 명세서와 일치하나요?

## 📝 리뷰 요청 사항
> 리뷰어가 집중해서 봐줬으면 하는 부분을 적어주세요.
> (없으면 삭제)

## 📷 스크린샷
> API 테스트 결과 등 첨부하면 좋아요.
<img width="1159" height="637" alt="스크린샷 2026-04-06 오후 1 05 10" src="https://github.com/user-attachments/assets/5aa59e86-fcbd-4a25-a45f-cbbba1613b68" />





