### PR TITLE
[fix] hub 권한 별 접근 수정

### DIFF
--- a/hub-service/build.gradle
+++ b/hub-service/build.gradle
@@ -4,5 +4,4 @@ dependencies {
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-database-postgresql'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 }

--- a/hub-service/src/main/java/com/sparta/lucky/hub/common/config/SecurityConfig.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/common/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.sparta.lucky.hub.common.filter.HeaderAuthenticationFilter;
 import com.sparta.lucky.hub.common.filter.InternalRequestFilter;
 import com.sparta.lucky.hub.common.filter.SecurityExceptionHandlerFilter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -12,6 +13,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.servlet.HandlerExceptionResolver;
 
 @Configuration
 @EnableWebSecurity
@@ -19,9 +21,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final SecurityExceptionHandlerFilter securityExceptionHandlerFilter;
-    private final HeaderAuthenticationFilter headerAuthenticationFilter;
-    private final InternalRequestFilter internalRequestFilter;
+    @Qualifier("handlerExceptionResolver")
+    private final HandlerExceptionResolver handlerExceptionResolver;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -40,9 +41,9 @@ public class SecurityConfig {
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(securityExceptionHandlerFilter, InternalRequestFilter.class)
-                .addFilterBefore(internalRequestFilter, UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(headerAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new SecurityExceptionHandlerFilter(handlerExceptionResolver), InternalRequestFilter.class)
+                .addFilterBefore(new InternalRequestFilter(), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new HeaderAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 }

--- a/hub-service/src/main/java/com/sparta/lucky/hub/common/config/SecurityConfig.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/common/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.sparta.lucky.hub.common.config;
 
 import com.sparta.lucky.hub.common.filter.HeaderAuthenticationFilter;
 import com.sparta.lucky.hub.common.filter.InternalRequestFilter;
+import com.sparta.lucky.hub.common.filter.SecurityExceptionHandlerFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -18,6 +19,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final SecurityExceptionHandlerFilter securityExceptionHandlerFilter;
     private final HeaderAuthenticationFilter headerAuthenticationFilter;
     private final InternalRequestFilter internalRequestFilter;
 
@@ -38,6 +40,7 @@ public class SecurityConfig {
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
+                .addFilterBefore(securityExceptionHandlerFilter, InternalRequestFilter.class)
                 .addFilterBefore(internalRequestFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(headerAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();

--- a/hub-service/src/main/java/com/sparta/lucky/hub/common/config/SecurityConfig.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/common/config/SecurityConfig.java
@@ -1,37 +1,42 @@
 package com.sparta.lucky.hub.common.config;
 
 import com.sparta.lucky.hub.common.filter.HeaderAuthenticationFilter;
-import com.sparta.lucky.hub.common.filter.InternalRequestFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final HeaderAuthenticationFilter headerAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-//                        .requestMatchers(
-//                                "/swagger-ui/**",
-//                                "/swagger-ui.html",
-//                                "/v3/api-docs/**",
-//                                "/api-docs/**"
-//                        ).permitAll()
-//                        .anyRequest().authenticated()
-                        // 현재는 모든 요청 permitAll
-                        .anyRequest().permitAll()
-                );
-//                .addFilterBefore(new InternalRequestFilter(), UsernamePasswordAuthenticationFilter.class)
-//                .addFilterBefore(new HeaderAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs/**",
+                                "/api-docs/**",
+                                "/internal/api/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(headerAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 }

--- a/hub-service/src/main/java/com/sparta/lucky/hub/common/config/SecurityConfig.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/common/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.sparta.lucky.hub.common.config;
 
 import com.sparta.lucky.hub.common.filter.HeaderAuthenticationFilter;
+import com.sparta.lucky.hub.common.filter.InternalRequestFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -18,6 +19,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final HeaderAuthenticationFilter headerAuthenticationFilter;
+    private final InternalRequestFilter internalRequestFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -32,10 +34,11 @@ public class SecurityConfig {
                                 "/swagger-ui.html",
                                 "/v3/api-docs/**",
                                 "/api-docs/**",
-                                "/internal/api/**"
+                                "/internal/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
+                .addFilterBefore(internalRequestFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(headerAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }

--- a/hub-service/src/main/java/com/sparta/lucky/hub/common/config/SecurityConfig.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/common/config/SecurityConfig.java
@@ -41,9 +41,9 @@ public class SecurityConfig {
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(new SecurityExceptionHandlerFilter(handlerExceptionResolver), InternalRequestFilter.class)
                 .addFilterBefore(new InternalRequestFilter(), UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(new HeaderAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new HeaderAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new SecurityExceptionHandlerFilter(handlerExceptionResolver), InternalRequestFilter.class);
         return http.build();
     }
 }

--- a/hub-service/src/main/java/com/sparta/lucky/hub/common/exception/GlobalExceptionHandler.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/common/exception/GlobalExceptionHandler.java
@@ -8,6 +8,8 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -32,6 +34,20 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(ApiResponse.error("INVALID_INPUT", message));
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMissingParam(MissingServletRequestParameterException e) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error("INVALID_INPUT", "필수 파라미터가 없습니다: " + e.getParameterName()));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<Void>> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error("INVALID_INPUT", "파라미터 형식이 올바르지 않습니다: " + e.getName()));
     }
 
     @ExceptionHandler({AccessDeniedException.class, AuthorizationDeniedException.class})

--- a/hub-service/src/main/java/com/sparta/lucky/hub/common/exception/GlobalExceptionHandler.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/common/exception/GlobalExceptionHandler.java
@@ -4,6 +4,9 @@ import com.sparta.lucky.hub.common.response.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -29,6 +32,20 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(ApiResponse.error("INVALID_INPUT", message));
+    }
+
+    @ExceptionHandler({AccessDeniedException.class, AuthorizationDeniedException.class})
+    public ResponseEntity<ApiResponse<Void>> handleAccessDeniedException(RuntimeException e) {
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
+                .body(ApiResponse.error("FORBIDDEN", "접근 권한이 없습니다."));
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAuthenticationException(AuthenticationException e) {
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(ApiResponse.error("UNAUTHORIZED", "인증이 필요합니다."));
     }
 
     @ExceptionHandler(Exception.class)

--- a/hub-service/src/main/java/com/sparta/lucky/hub/common/filter/HeaderAuthenticationFilter.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/common/filter/HeaderAuthenticationFilter.java
@@ -4,14 +4,22 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+@Component
+@Slf4j
 public class HeaderAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
@@ -20,14 +28,23 @@ public class HeaderAuthenticationFilter extends OncePerRequestFilter {
                                     FilterChain filterChain) throws ServletException, IOException {
         String userId = request.getHeader("X-User-Id");
         String role = request.getHeader("X-User-Role");
+        String hubId = request.getHeader("X-Hub-Id");
+        String companyId = request.getHeader("X-Company-Id");
 
-        if (userId != null && !userId.isBlank() && role != null && !role.isBlank()) {
-            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-                    userId,
-                    null,
-                    List.of(new SimpleGrantedAuthority("ROLE_" + role))
-            );
+        if (StringUtils.hasText(userId) && StringUtils.hasText(role)) {
+            List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_" + role));
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(userId, null, authorities);
+
+            Map<String, String> details = new HashMap<>();
+            details.put("hubId", hubId);
+            details.put("companyId", companyId);
+            authentication.setDetails(details);
+
             SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            log.debug("Authenticated User: {}, Role: {}", userId, role);
         }
 
         filterChain.doFilter(request, response);

--- a/hub-service/src/main/java/com/sparta/lucky/hub/common/filter/HeaderAuthenticationFilter.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/common/filter/HeaderAuthenticationFilter.java
@@ -9,7 +9,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -18,7 +17,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@Component
 @Slf4j
 public class HeaderAuthenticationFilter extends OncePerRequestFilter {
 

--- a/hub-service/src/main/java/com/sparta/lucky/hub/common/filter/InternalRequestFilter.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/common/filter/InternalRequestFilter.java
@@ -6,12 +6,10 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
-@Component
 public class InternalRequestFilter extends OncePerRequestFilter {
 
     private static final String INTERNAL_PATH_PREFIX = "/internal/";

--- a/hub-service/src/main/java/com/sparta/lucky/hub/common/filter/InternalRequestFilter.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/common/filter/InternalRequestFilter.java
@@ -6,10 +6,12 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+@Component
 public class InternalRequestFilter extends OncePerRequestFilter {
 
     private static final String INTERNAL_PATH_PREFIX = "/internal/";

--- a/hub-service/src/main/java/com/sparta/lucky/hub/common/filter/SecurityExceptionHandlerFilter.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/common/filter/SecurityExceptionHandlerFilter.java
@@ -1,0 +1,43 @@
+package com.sparta.lucky.hub.common.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import java.io.IOException;
+
+// 필터 체인에서 발생한 인증/인가 예외를 GlobalExceptionHandler로 위임하는 필터
+@Slf4j
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class SecurityExceptionHandlerFilter extends OncePerRequestFilter {
+
+    private final HandlerExceptionResolver resolver;
+
+    public SecurityExceptionHandlerFilter(
+            @Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (AuthenticationException | AccessDeniedException e) {
+            log.warn("Security exception: {}", e.getMessage());
+            resolver.resolveException(request, response, null, e);
+        }
+    }
+}

--- a/hub-service/src/main/java/com/sparta/lucky/hub/common/filter/SecurityExceptionHandlerFilter.java
+++ b/hub-service/src/main/java/com/sparta/lucky/hub/common/filter/SecurityExceptionHandlerFilter.java
@@ -5,12 +5,8 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.core.Ordered;
-import org.springframework.core.annotation.Order;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 
@@ -18,14 +14,11 @@ import java.io.IOException;
 
 // 필터 체인에서 발생한 인증/인가 예외를 GlobalExceptionHandler로 위임하는 필터
 @Slf4j
-@Component
-@Order(Ordered.HIGHEST_PRECEDENCE)
 public class SecurityExceptionHandlerFilter extends OncePerRequestFilter {
 
     private final HandlerExceptionResolver resolver;
 
-    public SecurityExceptionHandlerFilter(
-            @Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver) {
+    public SecurityExceptionHandlerFilter(HandlerExceptionResolver resolver) {
         this.resolver = resolver;
     }
 

--- a/hub-service/src/main/resources/application.yaml
+++ b/hub-service/src/main/resources/application.yaml
@@ -38,13 +38,6 @@ spring:
     virtual:
       enabled: true
 
-  security:
-    oauth2:
-      resourceserver:
-        jwt:
-          issuer-uri: http://localhost:9090/realms/lucky
-          jwk-set-uri: http://lucky-keycloak:8080/realms/lucky/protocol/openid-connect/certs
-
 eureka:
   client:
     service-url:


### PR DESCRIPTION
## 📋 관련 이슈
> 관련 이슈 번호를 적어주세요.
- close #

## 🔧 작업 내용

1. 진영님이 알려주신 대로 수정했습니다.
2. 추가로 InternalRequestFilter 사용했습니다. (X-Internal-Request가 true인지 확인용)

### /internal/** 요청
[InternalRequestFilter]
→ X-Internal-Request 헤더 없음 → BusinessException                                                    
→ 헤더 있음 → 통과

### /api/** 요청
[InternalRequestFilter]
→ /internal/ 아니므로 그냥 통과

[HeaderAuthenticationFilter]
→ X-User-Id / X-User-Role 읽어서 SecurityContext 설정
anyRequest().authenticated()
→ SecurityContext에 인증 없으면 → 403
→ @PreAuthorize("hasRole('MASTER')") → 권한 없으면 → 403


## ✅ 체크리스트
- [ ] 코드 컨벤션을 지켰나요?
- [ ] 불필요한 주석/코드를 제거했나요?
- [ ] 로컬에서 테스트 완료했나요?
- [ ] API 명세서와 일치하나요?




